### PR TITLE
Support custom data type's load/save, add extra apis.

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -7,6 +7,18 @@ use crate::raw;
 use crate::LogLevel;
 use crate::{RedisError, RedisResult, RedisString, RedisValue};
 
+const FMT0: *const i8 = b"\0".as_ptr() as *const i8;
+const FMT1: *const i8 = b"s\0".as_ptr() as *const i8;
+const FMT2: *const i8 = b"ss\0".as_ptr() as *const i8;
+const FMT3: *const i8 = b"sss\0".as_ptr() as *const i8;
+const FMT4: *const i8 = b"ssss\0".as_ptr() as *const i8;
+const FMT5: *const i8 = b"sssss\0".as_ptr() as *const i8;
+const FMT6: *const i8 = b"ssssss\0".as_ptr() as *const i8;
+const FMT7: *const i8 = b"sssssss\0".as_ptr() as *const i8;
+const FMT8: *const i8 = b"ssssssss\0".as_ptr() as *const i8;
+const FMT9: *const i8 = b"sssssssss\0".as_ptr() as *const i8;
+const FMT10: *const i8 = b"ssssssssss\0".as_ptr() as *const i8;
+
 /// Redis is a structure that's designed to give us a high-level interface to
 /// the Redis module API by abstracting away the raw C FFI calls.
 pub struct Context {
@@ -34,23 +46,54 @@ impl Context {
         self.log(LogLevel::Notice, message);
     }
 
-    pub fn call(&self, command: &str, args: &[&str]) -> RedisResult {
-        let terminated_args: Vec<RedisString> = args
+    pub fn auto_memory(&self) {
+        unsafe {raw::RedisModule_AutoMemory.unwrap()(self.ctx);}
+    }
+
+    pub fn call(&self, cmd: &str, args: &[&str]) -> RedisResult {
+        let args: Vec<RedisString> = args
             .iter()
             .map(|s| RedisString::create(self.ctx, s))
             .collect();
+        let cmd = CString::new(cmd).unwrap();
+        let reply: *mut raw::RedisModuleCallReply = unsafe {
+            let p_call = raw::RedisModule_Call.unwrap();
+            match args.len() {
+                0 => p_call(self.ctx, cmd.as_ptr(), FMT0),
+                1 => p_call(self.ctx, cmd.as_ptr(), FMT1, args[0].inner as *mut i8),
+                2 => p_call(self.ctx, cmd.as_ptr(), FMT2, args[0].inner as *mut i8, args[1].inner as *mut i8),
+                3 => p_call(self.ctx, cmd.as_ptr(), FMT3, args[0].inner as *mut i8, args[1].inner as *mut i8, args[2].inner as *mut i8),
+                4 => p_call(self.ctx, cmd.as_ptr(), FMT4, args[0].inner as *mut i8, args[1].inner as *mut i8, args[2].inner as *mut i8, args[3].inner as *mut i8),
+                5 => p_call(self.ctx, cmd.as_ptr(), FMT5, args[0].inner as *mut i8, args[1].inner as *mut i8, args[2].inner as *mut i8, args[3].inner as *mut i8, args[4].inner as *mut i8),
+                6 => p_call(self.ctx, cmd.as_ptr(), FMT6, args[0].inner as *mut i8, args[1].inner as *mut i8, args[2].inner as *mut i8, args[3].inner as *mut i8, args[4].inner as *mut i8, args[5].inner as *mut i8),
+                7 => p_call(self.ctx, cmd.as_ptr(), FMT7, args[0].inner as *mut i8, args[1].inner as *mut i8, args[2].inner as *mut i8, args[3].inner as *mut i8, args[4].inner as *mut i8, args[5].inner as *mut i8, args[6].inner as *mut i8),
+                8 => p_call(self.ctx, cmd.as_ptr(), FMT8, args[0].inner as *mut i8, args[1].inner as *mut i8, args[2].inner as *mut i8, args[3].inner as *mut i8, args[4].inner as *mut i8, args[5].inner as *mut i8, args[6].inner as *mut i8, args[7].inner as *mut i8),
+                9 => p_call(self.ctx, cmd.as_ptr(), FMT9, args[0].inner as *mut i8, args[1].inner as *mut i8, args[2].inner as *mut i8, args[3].inner as *mut i8, args[4].inner as *mut i8, args[5].inner as *mut i8, args[6].inner as *mut i8, args[7].inner as *mut i8, args[8].inner as *mut i8),
+                10 => p_call(self.ctx, cmd.as_ptr(), FMT10, args[0].inner as *mut i8, args[1].inner as *mut i8, args[2].inner as *mut i8, args[3].inner as *mut i8, args[4].inner as *mut i8, args[5].inner as *mut i8, args[6].inner as *mut i8, args[7].inner as *mut i8, args[8].inner as *mut i8, args[9].inner as *mut i8),
+                _ => {return Err(RedisError::Str("too many arguments"));}
+            }
+        };
 
-        let _ = terminated_args;
-        let _ = command;
-        let _ = args;
-
-        return Err(RedisError::Str("not implemented"));
+        let result = match raw::call_reply_type(reply) {
+            raw::ReplyType::Unknown | raw::ReplyType::Error => {
+                Err(RedisError::String(raw::call_reply_string(reply)))
+            }
+            _ => {
+                Ok(RedisValue::SimpleStringStatic("OK"))
+            }
+        };
+        raw::free_call_reply(reply);
+        result
     }
 
     pub fn reply(&self, r: RedisResult) -> raw::Status {
         match r {
             Ok(RedisValue::Integer(v)) => unsafe {
                 raw::RedisModule_ReplyWithLongLong.unwrap()(self.ctx, v).into()
+            },
+
+            Ok(RedisValue::Float(v)) => unsafe {
+                raw::RedisModule_ReplyWithDouble.unwrap()(self.ctx, v).into()
             },
 
             Ok(RedisValue::SimpleStringStatic(s)) => unsafe {
@@ -111,5 +154,9 @@ impl Context {
 
     pub fn open_key_writable(&self, key: &str) -> RedisKeyWritable {
         RedisKeyWritable::open(self.ctx, key)
+    }
+
+    pub fn replicate_verbatim(&self) {
+        raw::replicate_verbatim(self.ctx);
     }
 }

--- a/src/key.rs
+++ b/src/key.rs
@@ -1,4 +1,3 @@
-use std::fmt::Debug;
 use std::os::raw::c_void;
 use std::ptr;
 use std::string;
@@ -47,7 +46,7 @@ impl RedisKey {
         }
     }
 
-    pub fn get_value<T: Debug>(
+    pub fn get_value<T>(
         &self,
         redis_type: &RedisType,
     ) -> Result<Option<&T>, RedisError> {
@@ -166,7 +165,7 @@ impl RedisKeyWritable {
         key_type == KeyType::Empty
     }
 
-    pub fn get_value<T: Debug>(
+    pub fn get_value<T>(
         &self,
         redis_type: &RedisType,
     ) -> Result<Option<&mut T>, RedisError> {
@@ -182,7 +181,7 @@ impl RedisKeyWritable {
         Ok(Some(value))
     }
 
-    pub fn set_value<T: Debug>(&self, redis_type: &RedisType, value: T) -> Result<(), RedisError> {
+    pub fn set_value<T>(&self, redis_type: &RedisType, value: T) -> Result<(), RedisError> {
         verify_type(self.key_inner, redis_type)?;
         let value = Box::into_raw(Box::new(value)) as *mut c_void;
         let status: raw::Status = unsafe {

--- a/src/native_types.rs
+++ b/src/native_types.rs
@@ -1,12 +1,9 @@
 use std::cell::RefCell;
-use std::ffi::CString;
-use std::os::raw::{c_int, c_void};
 use std::ptr;
-
 use crate::raw;
 
 pub struct RedisType {
-    name: &'static str,
+    pub name: &'static str,
     pub raw_type: RefCell<*mut raw::RedisModuleType>,
 }
 
@@ -20,91 +17,5 @@ impl RedisType {
             name,
             raw_type: RefCell::new(ptr::null_mut()),
         }
-    }
-
-    pub fn create_data_type(&self, ctx: *mut raw::RedisModuleCtx) -> Result<(), &str> {
-        if self.name.len() != 9 {
-            let msg = "Redis requires the length of native type names to be exactly 9 characters";
-            redis_log(ctx, format!("{}, name is: '{}'", msg, self.name).as_str());
-            return Err(msg);
-        }
-
-        let type_name = CString::new(self.name).unwrap();
-
-        let mut type_methods = raw::RedisModuleTypeMethods {
-            version: raw::REDISMODULE_TYPE_METHOD_VERSION as u64,
-
-            rdb_load: Some(MyTypeRdbLoad),
-            rdb_save: Some(MyTypeRdbSave),
-            aof_rewrite: Some(MyTypeAofRewrite),
-            free: Some(MyTypeFree),
-
-            // Currently unused by Redis
-            mem_usage: None,
-            digest: None,
-        };
-
-        let redis_type = unsafe {
-            raw::RedisModule_CreateDataType.unwrap()(
-                ctx,
-                type_name.as_ptr(),
-                0, // Encoding version
-                &mut type_methods,
-            )
-        };
-
-        if redis_type.is_null() {
-            redis_log(ctx, "Error: created data type is null");
-            return Err("Error: created data type is null");
-        }
-
-        *self.raw_type.borrow_mut() = redis_type;
-
-        redis_log(
-            ctx,
-            format!("Created new data type '{}'", self.name).as_str(),
-        );
-
-        Ok(())
-    }
-}
-
-// FIXME: Generate these methods with a macro, since we need a set for each custom data type.
-
-#[allow(non_snake_case, unused)]
-#[no_mangle] // FIXME This should be unneeded
-pub unsafe extern "C" fn MyTypeRdbLoad(rdb: *mut raw::RedisModuleIO, encver: c_int) -> *mut c_void {
-    //    eprintln!("MyTypeRdbLoad");
-    ptr::null_mut()
-}
-
-#[allow(non_snake_case, unused)]
-#[no_mangle]
-pub unsafe extern "C" fn MyTypeRdbSave(rdb: *mut raw::RedisModuleIO, value: *mut c_void) {
-    //    eprintln!("MyTypeRdbSave");
-}
-
-#[allow(non_snake_case, unused)]
-#[no_mangle]
-pub unsafe extern "C" fn MyTypeAofRewrite(
-    aof: *mut raw::RedisModuleIO,
-    key: *mut raw::RedisModuleString,
-    value: *mut c_void,
-) {
-    //    eprintln!("MyTypeAofRewrite");
-}
-
-#[allow(non_snake_case, unused)]
-#[no_mangle]
-pub unsafe extern "C" fn MyTypeFree(value: *mut c_void) {
-    //    eprintln!("MyTypeFree");
-}
-
-// TODO: Move to raw
-pub fn redis_log(ctx: *mut raw::RedisModuleCtx, msg: &str) {
-    let level = CString::new("notice").unwrap(); // FIXME reuse this
-    let msg = CString::new(msg).unwrap();
-    unsafe {
-        raw::RedisModule_Log.unwrap()(ctx, level.as_ptr(), msg.as_ptr());
     }
 }

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -14,6 +14,7 @@ use num_traits::FromPrimitive;
 use libc::size_t;
 
 pub use crate::redisraw::bindings::*;
+use crate::RedisString;
 
 bitflags! {
     pub struct KeyMode: c_int {
@@ -228,4 +229,15 @@ pub fn string_set(key: *mut RedisModuleKey, str: *mut RedisModuleString) -> Stat
 
 pub fn replicate_verbatim(ctx: *mut RedisModuleCtx) -> Status {
     unsafe { RedisModule_ReplicateVerbatim.unwrap()(ctx).into() }
+}
+
+pub fn load_string(rdb: *mut RedisModuleIO) -> String {
+    let p = unsafe { RedisModule_LoadString.unwrap()(rdb) };
+    RedisString::from_ptr(p)
+        .expect("UTF8 encoding error in load string")
+        .to_string()
+}
+
+pub fn save_string(rdb: *mut RedisModuleIO, buf: &String) {
+    unsafe { RedisModule_SaveStringBuffer.unwrap()(rdb, buf.as_ptr() as *mut i8, buf.len()) };
 }


### PR DESCRIPTION
Support custom data type's load/save operation, by moving the type methods table into the user's code. [example](https://github.com/cryptorelay/redis-aggregation/blob/master/src/lib.rs#L554)