### PR TITLE
Introduce the `experimental-api` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,3 +27,7 @@ num-traits = "^0.2"
 [build-dependencies]
 bindgen = "0.51"
 cc = "1.0"
+
+[features]
+default = []
+experimental-api = []

--- a/build.rs
+++ b/build.rs
@@ -9,13 +9,26 @@ fn main() {
     // src/redismodule.c is a stub that includes it and plays a few other
     // tricks that we need to complete the build.
 
-    cc::Build::new()
+    let mut build = cc::Build::new();
+
+    // if the `experimental-api` is enabled
+    if std::env::var_os("CARGO_FEATURE_EXPERIMENTAL_API").is_some() {
+        build.define("REDISMODULE_EXPERIMENTAL_API", None);
+    }
+
+    build
         .file("src/redismodule.c")
         .include("src/include/")
         .compile("redismodule");
 
-    let bindings = bindgen::Builder::default()
-        .clang_arg("-DREDISMODULE_EXPERIMENTAL_API")
+    let mut build = bindgen::Builder::default();
+
+    // if the `experimental-api` is enabled
+    if std::env::var_os("CARGO_FEATURE_EXPERIMENTAL_API").is_some() {
+        build = build.clang_arg("-DREDISMODULE_EXPERIMENTAL_API");
+    }
+
+    let bindings = build
         .header("src/include/redismodule.h")
         .whitelist_var("(REDIS|Redis).*")
         .generate()

--- a/build.rs
+++ b/build.rs
@@ -9,11 +9,17 @@ fn main() {
     // src/redismodule.c is a stub that includes it and plays a few other
     // tricks that we need to complete the build.
 
+    const EXPERIMENTAL_API: &str = "REDISMODULE_EXPERIMENTAL_API";
+
+    // Determine if the `experimental-api` feature is enabled
+    fn experimental_api() -> bool {
+        std::env::var_os("CARGO_FEATURE_EXPERIMENTAL_API").is_some()
+    }
+
     let mut build = cc::Build::new();
 
-    // if the `experimental-api` is enabled
-    if std::env::var_os("CARGO_FEATURE_EXPERIMENTAL_API").is_some() {
-        build.define("REDISMODULE_EXPERIMENTAL_API", None);
+    if experimental_api() {
+        build.define(EXPERIMENTAL_API, None);
     }
 
     build
@@ -23,9 +29,8 @@ fn main() {
 
     let mut build = bindgen::Builder::default();
 
-    // if the `experimental-api` is enabled
-    if std::env::var_os("CARGO_FEATURE_EXPERIMENTAL_API").is_some() {
-        build = build.clang_arg("-DREDISMODULE_EXPERIMENTAL_API");
+    if experimental_api() {
+        build = build.clang_arg(format!("-D{}", EXPERIMENTAL_API).as_str());
     }
 
     let bindings = build

--- a/src/redismodule.c
+++ b/src/redismodule.c
@@ -1,4 +1,3 @@
-#define REDISMODULE_EXPERIMENTAL_API
 #include "redismodule.h"
 
 // RedisModule_Init is defined as a static function and so won't be exported as


### PR DESCRIPTION
This way it will be possible to enable or disable the Redis experimental-api and therefore not risk using them by mistake.

Every future Rust bindings above experimental function must be marked like so:
```rust
#[cfg(feature = "experimental-api")]
pub fn get_thread_safe_context() -> *mut RedisModuleCtx {
    unsafe { RedisModule_GetThreadSafeContext.unwrap()(std::ptr::null_mut()) }
}
```