### PR TITLE
cleaner way to use redis allocator

### DIFF
--- a/src/alloc.rs
+++ b/src/alloc.rs
@@ -1,12 +1,9 @@
 use std::alloc::{GlobalAlloc, Layout};
 use std::os::raw::c_void;
-use std::sync::atomic::{AtomicBool, Ordering::SeqCst};
 
 use crate::raw;
 
 pub struct RedisAlloc;
-
-static USE_REDIS_ALLOC: AtomicBool = AtomicBool::new(false);
 
 unsafe impl GlobalAlloc for RedisAlloc {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
@@ -17,9 +14,4 @@ unsafe impl GlobalAlloc for RedisAlloc {
     unsafe fn dealloc(&self, ptr: *mut u8, _layout: Layout) {
         return raw::RedisModule_Free.unwrap()(ptr as *mut c_void);
     }
-}
-
-pub fn use_redis_alloc() {
-    USE_REDIS_ALLOC.store(true, SeqCst);
-    eprintln!("Now using Redis allocator");
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,7 @@ mod key;
 pub use crate::context::Context;
 pub use crate::redismodule::*;
 
+#[cfg(not(test))]
 #[global_allocator]
 static ALLOC: crate::alloc::RedisAlloc = crate::alloc::RedisAlloc;
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -79,19 +79,24 @@ macro_rules! redis_module {
             _argv: *mut *mut raw::RedisModuleString,
             _argc: c_int,
         ) -> c_int {
-            {
+            let mut name_buffer = [0; 64];
+                  let mut dest = name_buffer.as_mut_ptr();
+            for byte in $module_name.chars() {
+                unsafe {
+                    *dest = byte as i8;
+                    dest = dest.add(1);
+                }
+            }
                 // We use an explicit block here to make sure all memory allocated before we
                 // switch to the Redis allocator will be out of scope and thus deallocated.
-                let module_name = CString::new($module_name).unwrap();
                 let module_version = $module_version as c_int;
 
                 if unsafe { raw::Export_RedisModule_Init(
                     ctx,
-                    module_name.as_ptr(),
+                    name_buffer.as_ptr() as *const std::os::raw::c_char,
                     module_version,
                     raw::REDISMODULE_APIVER_1 as c_int,
                 ) } == raw::Status::Err as c_int { return raw::Status::Err as c_int; }
-            }
 
             if true {
                 redis_module::alloc::use_redis_alloc();

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -65,7 +65,7 @@ macro_rules! redis_module {
               ]),* $(,)*
         ] $(,)*
     ) => {
-        use std::os::raw::c_int;
+        use std::os::raw::{c_int, c_char};
         use std::ffi::CString;
         use std::slice;
 
@@ -80,7 +80,7 @@ macro_rules! redis_module {
             _argc: c_int,
         ) -> c_int {
             let mut name_buffer = [0; 64];
-                  let mut dest = name_buffer.as_mut_ptr();
+            let mut dest = name_buffer.as_mut_ptr();
             for byte in $module_name.chars() {
                 unsafe {
                     *dest = byte as i8;
@@ -93,7 +93,7 @@ macro_rules! redis_module {
 
             if unsafe { raw::Export_RedisModule_Init(
                 ctx,
-                name_buffer.as_ptr() as *const std::os::raw::c_char,
+                name_buffer.as_ptr() as *const c_char,
                 module_version,
                 raw::REDISMODULE_APIVER_1 as c_int,
             ) } == raw::Status::Err as c_int { return raw::Status::Err as c_int; }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -87,22 +87,16 @@ macro_rules! redis_module {
                     dest = dest.add(1);
                 }
             }
-                // We use an explicit block here to make sure all memory allocated before we
-                // switch to the Redis allocator will be out of scope and thus deallocated.
-                let module_version = $module_version as c_int;
+            // We use an explicit block here to make sure all memory allocated before we
+            // switch to the Redis allocator will be out of scope and thus deallocated.
+            let module_version = $module_version as c_int;
 
-                if unsafe { raw::Export_RedisModule_Init(
-                    ctx,
-                    name_buffer.as_ptr() as *const std::os::raw::c_char,
-                    module_version,
-                    raw::REDISMODULE_APIVER_1 as c_int,
-                ) } == raw::Status::Err as c_int { return raw::Status::Err as c_int; }
-
-            if true {
-                redis_module::alloc::use_redis_alloc();
-            } else {
-                eprintln!("*** NOT USING Redis allocator ***");
-            }
+            if unsafe { raw::Export_RedisModule_Init(
+                ctx,
+                name_buffer.as_ptr() as *const std::os::raw::c_char,
+                module_version,
+                raw::REDISMODULE_APIVER_1 as c_int,
+            ) } == raw::Status::Err as c_int { return raw::Status::Err as c_int; }
 
             $(
                 if $init_func(ctx) == raw::Status::Err as c_int {


### PR DESCRIPTION
This needs to be formatted, by for some exoteric reason today my formatter does not work on this machine.

Anyway, this PR allow to use the redis allocator without the ugly check at compile time. The tradeoff is limiting the name of the redis module, now it is limited to 64-1 chars, of course it can be increased.

I prepare this PR in response to this tweet: https://twitter.com/croloris/status/1231318432068653056 and the related post: https://engineering.redislabs.com/posts/using-the-redis-allocator-in-rust/

I will complete and format the PR later :)