### PR TITLE
Add Support for CreateCommand Keys

### DIFF
--- a/examples/data_type.rs
+++ b/examples/data_type.rs
@@ -83,7 +83,7 @@ redis_module! {
         MY_REDIS_TYPE,
     ],
     commands: [
-        ["alloc.set", alloc_set, "write"],
-        ["alloc.get", alloc_get, "readonly"],
+        ["alloc.set", alloc_set, "write", 1, 1, 1],
+        ["alloc.get", alloc_get, "readonly", 1, 1, 1],
     ],
 }

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -29,7 +29,7 @@ redis_module! {
     version: 1,
     data_types: [],
     commands: [
-        ["hello.mul", hello_mul, ""],
+        ["hello.mul", hello_mul, "", 1, 1, 1],
     ],
 }
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,6 +1,12 @@
 #[macro_export]
 macro_rules! redis_command {
-    ($ctx:expr, $command_name:expr, $command_handler:expr, $command_flags:expr, $firstkey:expr, $lastkey:expr, $keystep:expr) => {{
+    ($ctx:expr,
+     $command_name:expr,
+     $command_handler:expr,
+     $command_flags:expr,
+     $firstkey:expr,
+     $lastkey:expr,
+     $keystep:expr) => {{
         let name = CString::new($command_name).unwrap();
         let flags = CString::new($command_flags).unwrap();
         let firstkey: i32 = $firstkey;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,9 +1,11 @@
 #[macro_export]
 macro_rules! redis_command {
-    ($ctx: expr, $command_name:expr, $command_handler:expr, $command_flags:expr) => {{
+    ($ctx:expr, $command_name:expr, $command_handler:expr, $command_flags:expr, $firstkey:expr, $lastkey:expr, $keystep:expr) => {{
         let name = CString::new($command_name).unwrap();
         let flags = CString::new($command_flags).unwrap();
-        let (firstkey, lastkey, keystep) = (1, 1, 1);
+        let firstkey: i32 = $firstkey;
+        let lastkey: i32 = $lastkey;
+        let keystep: i32 = $keystep;
 
         /////////////////////
         extern "C" fn do_command(
@@ -61,7 +63,10 @@ macro_rules! redis_module {
             $([
                 $name:expr,
                 $command:expr,
-                $flags:expr
+                $flags:expr,
+                $firstkey:expr,
+                $lastkey:expr,
+                $keystep:expr
               ]),* $(,)*
         ] $(,)*
     ) => {
@@ -112,7 +117,7 @@ macro_rules! redis_module {
             )*
 
             $(
-                redis_command!(ctx, $name, $command, $flags);
+                redis_command!(ctx, $name, $command, $flags, $firstkey, $lastkey, $keystep);
             )*
 
             raw::Status::Ok as c_int

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -9,9 +9,6 @@ macro_rules! redis_command {
      $keystep:expr) => {{
         let name = CString::new($command_name).unwrap();
         let flags = CString::new($command_flags).unwrap();
-        let firstkey: i32 = $firstkey;
-        let lastkey: i32 = $lastkey;
-        let keystep: i32 = $keystep;
 
         /////////////////////
         extern "C" fn do_command(
@@ -45,9 +42,9 @@ macro_rules! redis_command {
                 name.as_ptr(),
                 Some(do_command),
                 flags.as_ptr(),
-                firstkey,
-                lastkey,
-                keystep,
+                $firstkey,
+                $lastkey,
+                $keystep,
             )
         } == raw::Status::Err as c_int
         {


### PR DESCRIPTION
The CreateCommand firstkey, lastkey, and keystep defaults aren't working for a module I'm trying to work on. 

I'd really like to make this change non-breaking. But my macro fu is noob-level (at best) and I don't know how to glob all the values after the `$flags:expr` (or even if this is something rust macros support?) and then pass these values as a vec into `redis_command!`. This way we could set defaults instead of passing `1, 1, 1` for most commands.