### PR TITLE
Add support for RedisModule_IsKeysPositionRequest

### DIFF
--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -1,11 +1,20 @@
 #[macro_use]
 extern crate redis_module;
 
-use redis_module::{parse_integer, Context, RedisError, RedisResult};
+use redis_module::{parse_integer, Context, RedisError, RedisResult, RedisValue};
 
-fn hello_mul(_: &Context, args: Vec<String>) -> RedisResult {
+fn hello_mul(ctx: &Context, args: Vec<String>) -> RedisResult {
     if args.len() < 2 {
         return Err(RedisError::WrongArity);
+    }
+
+    if ctx.is_keys_position_request() {
+        for i in 1..args.len() {
+            if i % 2 == 0 {
+                ctx.key_at_pos(i as i32);
+            }
+        }
+        return Ok(RedisValue::NoReply);
     }
 
     let nums = args
@@ -29,7 +38,7 @@ redis_module! {
     version: 1,
     data_types: [],
     commands: [
-        ["hello.mul", hello_mul, "", 0, 0, 0],
+        ["hello.mul", hello_mul, "getkeys-api", 1, 1, 1],
     ],
 }
 

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -29,7 +29,7 @@ redis_module! {
     version: 1,
     data_types: [],
     commands: [
-        ["hello.mul", hello_mul, "", 1, 1, 1],
+        ["hello.mul", hello_mul, "", 0, 0, 0],
     ],
 }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -99,7 +99,7 @@ impl Context {
             }
             raw::ReplyType::Integer => Ok(RedisValue::Integer(raw::call_reply_integer(reply))),
             raw::ReplyType::String => Ok(RedisValue::SimpleString(raw::call_reply_string(reply))),
-            raw::ReplyType::Nil => Ok(RedisValue::None),
+            raw::ReplyType::Null => Ok(RedisValue::Null),
         }
     }
 
@@ -145,7 +145,7 @@ impl Context {
                 raw::Status::Ok
             }
 
-            Ok(RedisValue::None) => unsafe {
+            Ok(RedisValue::Null) => unsafe {
                 raw::RedisModule_ReplyWithNull.unwrap()(self.ctx).into()
             },
 

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -59,7 +59,7 @@ pub enum ReplyType {
     Error = REDISMODULE_REPLY_ERROR_ISIZE,
     Integer = REDISMODULE_REPLY_INTEGER_ISIZE,
     Array = REDISMODULE_REPLY_ARRAY_ISIZE,
-    Nil = REDISMODULE_REPLY_NULL_ISIZE,
+    Null = REDISMODULE_REPLY_NULL_ISIZE,
 }
 
 impl From<c_int> for ReplyType {

--- a/src/redisvalue.rs
+++ b/src/redisvalue.rs
@@ -7,6 +7,7 @@ pub enum RedisValue {
     Float(f64),
     Array(Vec<RedisValue>),
     Null,
+    NoReply, // No reply at all (as opposed to a Null reply)
 }
 
 impl From<()> for RedisValue {

--- a/src/redisvalue.rs
+++ b/src/redisvalue.rs
@@ -6,12 +6,12 @@ pub enum RedisValue {
     Integer(i64),
     Float(f64),
     Array(Vec<RedisValue>),
-    None,
+    Null,
 }
 
 impl From<()> for RedisValue {
     fn from(_: ()) -> Self {
-        RedisValue::None
+        RedisValue::Null
     }
 }
 
@@ -55,7 +55,7 @@ impl<T: Into<RedisValue>> From<Option<T>> for RedisValue {
     fn from(s: Option<T>) -> Self {
         match s {
             Some(v) => v.into(),
-            None => RedisValue::None,
+            None => RedisValue::Null,
         }
     }
 }
@@ -106,6 +106,6 @@ mod tests {
 
     #[test]
     fn from_option_none() {
-        assert_eq!(RedisValue::from(None::<()>), RedisValue::None,);
+        assert_eq!(RedisValue::from(None::<()>), RedisValue::Null,);
     }
 }


### PR DESCRIPTION
- Make a clear distinction between sending a NULL reply and sending no reply at all
- Wrap `RedisModule_IsKeysPositionRequest` and `RedisModule_KeyAtPos`
- Show usage in example