### PR TITLE
SubscribeKeyspaceEvent & Timer API's

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -40,6 +40,30 @@ impl Context {
         unsafe { raw::RedisModule_ThreadSafeContextUnlock.unwrap()(self.ctx) };
     }
 
+    #[cfg(feature = "experimental-api")]
+    pub fn create_timer(
+        &self,
+        period: u64,
+        callback: raw::RedisModuleTimerProc,
+        data: &str,
+    ) -> u64 {
+        raw::create_timer(self.ctx, period, callback, data)
+    }
+
+    #[cfg(feature = "experimental-api")]
+    pub fn stop_timer(&self, id: u64) -> i32 {
+        raw::stop_timer(self.ctx, id)
+    }
+
+    #[cfg(feature = "experimental-api")]
+    pub fn subscribe_to_keyspace_events(
+        &self,
+        types: i32,
+        callback: raw::RedisModuleNotificationFunc,
+    ) -> i32 {
+        raw::subscribe_to_keyspace_events(self.ctx, types, callback)
+    }
+
     pub fn log(&self, level: LogLevel, message: &str) {
         let level = CString::new(format!("{:?}", level).to_lowercase()).unwrap();
         let fmt = CString::new(message).unwrap();

--- a/src/context.rs
+++ b/src/context.rs
@@ -50,11 +50,35 @@ impl Context {
         raw::create_timer(self.ctx, period, callback, data)
     }
 
+    // stop_timer_data takes an timer_id and
+    // returns ok = 0, err = 1
     #[cfg(feature = "experimental-api")]
     pub fn stop_timer(&self, id: u64) -> i32 {
         raw::stop_timer(self.ctx, id)
     }
 
+    // stop_timer_data takes a timer_id and
+    // returns (ok, data stored with timer)
+    #[cfg(feature = "experimental-api")]
+    pub fn stop_timer_data(&self, id: u64) -> (i32, Option<String>) {
+        raw::stop_timer_data(self.ctx, id)
+    }
+
+    // get_timer_info takes the timer id and returns (ok, milliseconds remaining)
+    #[cfg(feature = "experimental-api")]
+    pub fn get_timer_info(&self, id: u64) -> (i32, u64) {
+        raw::get_timer_info(self.ctx, id)
+    }
+
+    // get_timer_info_data takes the timer id
+    // and returns (ok, milliseconds remaining, data stored with timer)
+    #[cfg(feature = "experimental-api")]
+    pub fn get_timer_info_data(&self, id: u64) -> (i32, u64, Option<String>) {
+        raw::get_timer_info_data(self.ctx, id)
+    }
+
+    // subscribe_to_keyspace_events registers callbacks
+    // for the `types` mask
     #[cfg(feature = "experimental-api")]
     pub fn subscribe_to_keyspace_events(
         &self,

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -375,7 +375,7 @@ pub fn create_timer(
             ctx,
             period as i64,
             callback,
-            Box::into_raw(Box::new(CString::new(data).unwrap())) as *mut _,
+            Box::into_raw(Box::new(CString::new(data).unwrap())) as *mut c_void,
         )
     }
 }

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -374,9 +374,9 @@ pub fn create_timer(
     }
 }
 
-// stop_timer kills the timer by id and passes a null ptr as the `data` value.
+// stop_timer kills the timer by id and sets `data` to null ptr.
 // the api supports passing `void **data` which will set **data to the existing
-// timer data before the timer is stopped. this is not supported.
+// timer data before the timer is stopped. this is not currently implemented.
 #[cfg(feature = "experimental-api")]
 pub fn stop_timer(ctx: *mut RedisModuleCtx, id: u64) -> i32 {
     unsafe { RedisModule_StopTimer.unwrap()(ctx, id, ptr::null_mut()) }

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -356,3 +356,37 @@ pub fn string_append_buffer(
         RedisModule_StringAppendBuffer.unwrap()(ctx, s, buff.as_ptr() as *mut i8, buff.len()).into()
     }
 }
+
+#[cfg(feature = "experimental-api")]
+pub fn create_timer(
+    ctx: *mut RedisModuleCtx,
+    period: u64,
+    callback: RedisModuleTimerProc,
+    data: &str,
+) -> u64 {
+    unsafe {
+        RedisModule_CreateTimer.unwrap()(
+            ctx,
+            period as i64,
+            callback,
+            Box::into_raw(Box::new(CString::new(data).unwrap())) as *mut _,
+        )
+    }
+}
+
+// stop_timer kills the timer by id and passes a null ptr as the `data` value.
+// the api supports passing `void **data` which will set **data to the existing
+// timer data before the timer is stopped. this is not supported.
+#[cfg(feature = "experimental-api")]
+pub fn stop_timer(ctx: *mut RedisModuleCtx, id: u64) -> i32 {
+    unsafe { RedisModule_StopTimer.unwrap()(ctx, id, ptr::null_mut()) }
+}
+
+#[cfg(feature = "experimental-api")]
+pub fn subscribe_to_keyspace_events(
+    ctx: *mut RedisModuleCtx,
+    types: i32,
+    callback: RedisModuleNotificationFunc,
+) -> i32 {
+    unsafe { RedisModule_SubscribeToKeyspaceEvents.unwrap()(ctx, types, callback) }
+}


### PR DESCRIPTION
This PR adds support for these API methods:

- `RedisModule_CreateTimer`
- `RedisModule_StopTimer`
- `RedisModule_GetTimerInfo`
- `RedisModule_SubscribeToKeyspaceEvents`

A few things I want to point out:

1. This was my first attempt at doing anything w/ Rust FFI & C Bindings. I really struggled with figuring out how to read data from a `*mut *mut c_void` without destroying the original pointer. If there's a better way to do this please let me know.

2. I'm currently passing `&str` for the `data` arg in `create_timer` only to convert it to a CString. Since the arg parser returns `Vec<String>` it might make more sense to change the `data` arg to String. What do you think?

3. I'm not entirely sure what the cleanest API here is for returning the "data" stored with a timer when you call `RedisModule_GetTimerInfo` or `RedisModule_StopTimer`. What I have here feels a little clunky returning a tuple. Maybe it needs a new return type or Enum?

I haven't created an issue to track this. Let me know if you think I should.