### PR TITLE
Cleaner way to use redis allocator

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,4 +56,4 @@ jobs:
 
       - run:
           name: Run all tests
-          command: cargo test --features experimental-api --all
+          command: cargo test --features test,experimental-api --all-targets

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,3 +36,7 @@ cc = "1.0"
 default = []
 experimental-api = []
 
+# Workaround to allow cfg(feature = "test") in dependencies:
+# https://github.com/rust-lang/rust/issues/59168#issuecomment-472653680
+# This requires running the tests with `--features test`
+test = []

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+cargo build --features experimental-api --all --all-targets
+

--- a/src/alloc.rs
+++ b/src/alloc.rs
@@ -1,12 +1,9 @@
 use std::alloc::{GlobalAlloc, Layout};
 use std::os::raw::c_void;
-use std::sync::atomic::{AtomicBool, Ordering::SeqCst};
 
 use crate::raw;
 
 pub struct RedisAlloc;
-
-static USE_REDIS_ALLOC: AtomicBool = AtomicBool::new(false);
 
 unsafe impl GlobalAlloc for RedisAlloc {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
@@ -17,9 +14,4 @@ unsafe impl GlobalAlloc for RedisAlloc {
     unsafe fn dealloc(&self, ptr: *mut u8, _layout: Layout) {
         return raw::RedisModule_Free.unwrap()(ptr as *mut c_void);
     }
-}
-
-pub fn use_redis_alloc() {
-    USE_REDIS_ALLOC.store(true, SeqCst);
-    eprintln!("Now using Redis allocator");
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -57,8 +57,8 @@ impl Context {
     }
 
     pub fn is_keys_position_request(&self) -> bool {
-        // HACK: Used for tests, where the context is null
-        if self.ctx.is_null() {
+        // We want this to be available in tests where we don't have an actual Redis to call
+        if cfg!(feature = "test") {
             return false;
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,10 @@ mod key;
 pub use crate::context::Context;
 pub use crate::redismodule::*;
 
-#[cfg(not(test))]
+/// Ideally this would be `#[cfg(not(test))]`, but that doesn't work:
+/// https://github.com/rust-lang/rust/issues/59168#issuecomment-472653680
+/// The workaround is to use the `test` feature instead.
+#[cfg(not(feature = "test"))]
 #[global_allocator]
 static ALLOC: crate::alloc::RedisAlloc = crate::alloc::RedisAlloc;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,7 @@ mod key;
 pub use crate::context::Context;
 pub use crate::redismodule::*;
 
+#[cfg(not(test))]
 #[global_allocator]
 static ALLOC: crate::alloc::RedisAlloc = crate::alloc::RedisAlloc;
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -87,19 +87,24 @@ macro_rules! redis_module {
             _argv: *mut *mut raw::RedisModuleString,
             _argc: c_int,
         ) -> c_int {
-            {
+            let mut name_buffer = [0; 64];
+                  let mut dest = name_buffer.as_mut_ptr();
+            for byte in $module_name.chars() {
+                unsafe {
+                    *dest = byte as i8;
+                    dest = dest.add(1);
+                }
+            }
                 // We use an explicit block here to make sure all memory allocated before we
                 // switch to the Redis allocator will be out of scope and thus deallocated.
-                let module_name = CString::new($module_name).unwrap();
                 let module_version = $module_version as c_int;
 
                 if unsafe { raw::Export_RedisModule_Init(
                     ctx,
-                    module_name.as_ptr(),
+                    name_buffer.as_ptr() as *const std::os::raw::c_char,
                     module_version,
                     raw::REDISMODULE_APIVER_1 as c_int,
                 ) } == raw::Status::Err as c_int { return raw::Status::Err as c_int; }
-            }
 
             if true {
                 redis_module::alloc::use_redis_alloc();

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -73,7 +73,7 @@ macro_rules! redis_module {
               ]),* $(,)*
         ] $(,)*
     ) => {
-        use std::os::raw::c_int;
+        use std::os::raw::{c_int, c_char};
         use std::ffi::CString;
         use std::slice;
 
@@ -88,7 +88,7 @@ macro_rules! redis_module {
             _argc: c_int,
         ) -> c_int {
             let mut name_buffer = [0; 64];
-                  let mut dest = name_buffer.as_mut_ptr();
+            let mut dest = name_buffer.as_mut_ptr();
             for byte in $module_name.chars() {
                 unsafe {
                     *dest = byte as i8;
@@ -101,7 +101,7 @@ macro_rules! redis_module {
 
             if unsafe { raw::Export_RedisModule_Init(
                 ctx,
-                name_buffer.as_ptr() as *const std::os::raw::c_char,
+                name_buffer.as_ptr() as *const c_char,
                 module_version,
                 raw::REDISMODULE_APIVER_1 as c_int,
             ) } == raw::Status::Err as c_int { return raw::Status::Err as c_int; }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -95,22 +95,16 @@ macro_rules! redis_module {
                     dest = dest.add(1);
                 }
             }
-                // We use an explicit block here to make sure all memory allocated before we
-                // switch to the Redis allocator will be out of scope and thus deallocated.
-                let module_version = $module_version as c_int;
+            // We use an explicit block here to make sure all memory allocated before we
+            // switch to the Redis allocator will be out of scope and thus deallocated.
+            let module_version = $module_version as c_int;
 
-                if unsafe { raw::Export_RedisModule_Init(
-                    ctx,
-                    name_buffer.as_ptr() as *const std::os::raw::c_char,
-                    module_version,
-                    raw::REDISMODULE_APIVER_1 as c_int,
-                ) } == raw::Status::Err as c_int { return raw::Status::Err as c_int; }
-
-            if true {
-                redis_module::alloc::use_redis_alloc();
-            } else {
-                eprintln!("*** NOT USING Redis allocator ***");
-            }
+            if unsafe { raw::Export_RedisModule_Init(
+                ctx,
+                name_buffer.as_ptr() as *const std::os::raw::c_char,
+                module_version,
+                raw::REDISMODULE_APIVER_1 as c_int,
+            ) } == raw::Status::Err as c_int { return raw::Status::Err as c_int; }
 
             $(
                 if $init_func(ctx) == raw::Status::Err as c_int {

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+cargo test --all-targets --features test,experimental-api


### PR DESCRIPTION
Based on PR #62 and extended to handle the `cfg(test)` limitation.