### PR TITLE
Improve macro hygiene by avoiding global `use` (fixes #30)

### DIFF
--- a/examples/data_type.rs
+++ b/examples/data_type.rs
@@ -2,7 +2,7 @@
 extern crate redis_module;
 
 use redis_module::native_types::RedisType;
-use redis_module::{Context, NextArg, RedisError, RedisResult};
+use redis_module::{raw, Context, NextArg, RedisError, RedisResult};
 use std::os::raw::c_void;
 
 #[derive(Debug)]

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -73,20 +73,19 @@ macro_rules! redis_module {
               ]),* $(,)*
         ] $(,)*
     ) => {
-        use std::os::raw::{c_int, c_char};
-        use std::ffi::CString;
-        use std::slice;
-
-        use redis_module::raw;
-        use redis_module::RedisString;
-
         #[no_mangle]
         #[allow(non_snake_case)]
         pub extern "C" fn RedisModule_OnLoad(
-            ctx: *mut raw::RedisModuleCtx,
-            _argv: *mut *mut raw::RedisModuleString,
-            _argc: c_int,
-        ) -> c_int {
+            ctx: *mut $crate::raw::RedisModuleCtx,
+            _argv: *mut *mut $crate::raw::RedisModuleString,
+            _argc: std::os::raw::c_int,
+        ) -> std::os::raw::c_int {
+            use std::os::raw::{c_int, c_char};
+            use std::ffi::CString;
+            use std::slice;
+
+            use $crate::raw;
+            use $crate::RedisString;
 
             // We use a statically sized buffer to avoid allocating.
             // This is needed since we use a custom allocator that relies on the Redis allocator,


### PR DESCRIPTION
- Use `$crate` to avoid hardcoding the module name, which may be
imported by the user under a different name
- Move `use` statements inside function bodies to avoid polluting the
enclosing module's namespace
- Fixes #30 
