### PR TITLE
Expose SubscribeToKeyspaceEvents (#77)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,10 +36,14 @@ required-features = ["experimental-api"]
 name = "data_type"
 crate-type = ["cdylib"]
 
-
 [[example]]
 name = "load_unload"
 crate-type = ["cdylib"]
+
+[[example]]
+name = "events"
+crate-type = ["cdylib"]
+required-features = ["experimental-api"]
 
 [dependencies]
 bitflags = "1.2"

--- a/build.rs
+++ b/build.rs
@@ -23,6 +23,8 @@ impl ParseCallbacks for RedisModuleCallback {
                 name: "isize",
                 is_signed: true,
             })
+        } else if name.starts_with("REDISMODULE_NOTIFY_") {
+            Some(IntKind::Int)
         } else {
             None
         }

--- a/examples/events.rs
+++ b/examples/events.rs
@@ -1,0 +1,34 @@
+#[macro_use]
+extern crate redis_module;
+
+use redis_module::{Context, NotifyEvent};
+
+fn on_event(ctx: &Context, event_type: NotifyEvent, event: &str, key: &str) {
+    let msg = format!(
+        "Received event: {:?} on key: {} via event: {}",
+        event_type, key, event
+    );
+    ctx.log_debug(msg.as_str());
+}
+
+fn on_stream(ctx: &Context, _event_type: NotifyEvent, _event: &str, _key: &str) {
+    ctx.log_debug("Stream event received!");
+}
+
+//////////////////////////////////////////////////////
+
+redis_module! {
+    name: "events",
+    version: 1,
+    data_types: [],
+    commands: [],
+    event_handlers: [
+        [@EXPIRED @EVICTED: on_event],
+        [@STREAM: on_stream],
+    ]
+}
+
+//////////////////////////////////////////////////////
+
+#[cfg(test)]
+mod tests {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,8 @@ mod macros;
 pub use crate::context::blocked::BlockedClient;
 #[cfg(feature = "experimental-api")]
 pub use crate::context::thread_safe::{DetachedFromClient, ThreadSafeContext};
+#[cfg(feature = "experimental-api")]
+pub use crate::raw::NotifyEvent;
 
 pub use crate::context::Context;
 pub use crate::redismodule::*;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -67,16 +67,18 @@ macro_rules! redis_event_handler {
             ctx: *mut $crate::raw::RedisModuleCtx,
             event_type: c_int,
             event: *const c_char,
-            key: *mut $crate::raw::RedisModuleString
+            key: *mut $crate::raw::RedisModuleString,
         ) -> c_int {
             let context = $crate::Context::new(ctx);
 
             let redis_key = $crate::RedisString::from_ptr(key).unwrap();
             let event_str = unsafe { CStr::from_ptr(event) };
-            $event_handler(&context,
+            $event_handler(
+                &context,
                 $crate::NotifyEvent::from_bits_truncate(event_type),
                 event_str.to_str().unwrap(),
-                redis_key);
+                redis_key,
+            );
 
             $crate::raw::Status::Ok as c_int
         }
@@ -85,9 +87,10 @@ macro_rules! redis_event_handler {
             $crate::raw::RedisModule_SubscribeToKeyspaceEvents.unwrap()(
                 $ctx,
                 $event_type.bits(),
-                Some(handle_event)
+                Some(handle_event),
             )
-        } == $crate::raw::Status::Err as c_int {
+        } == $crate::raw::Status::Err as c_int
+        {
             return $crate::raw::Status::Err as c_int;
         }
     }};

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -2,8 +2,6 @@
 // point.
 #![allow(dead_code)]
 
-use std::os::raw::{c_char, c_double, c_int, c_long, c_longlong};
-
 extern crate enum_primitive_derive;
 extern crate libc;
 extern crate num_traits;
@@ -13,6 +11,7 @@ use enum_primitive_derive::Primitive;
 use libc::size_t;
 use num_traits::FromPrimitive;
 use std::ffi::CString;
+use std::os::raw::{c_char, c_double, c_int, c_long, c_longlong};
 use std::ptr;
 use std::slice;
 
@@ -84,6 +83,22 @@ impl From<Status> for Result<(), &str> {
             Status::Ok => Ok(()),
             Status::Err => Err("Generic error"),
         }
+    }
+}
+
+#[cfg(feature = "experimental-api")]
+bitflags! {
+    pub struct NotifyEvent : i32 {
+        const GENERIC = REDISMODULE_NOTIFY_GENERIC as i32;
+        const STRING = REDISMODULE_NOTIFY_STRING as i32;
+        const LIST = REDISMODULE_NOTIFY_LIST as i32;
+        const SET = REDISMODULE_NOTIFY_SET as i32;
+        const HASH = REDISMODULE_NOTIFY_HASH as i32;
+        const ZSET = REDISMODULE_NOTIFY_ZSET as i32;
+        const EXPIRED = REDISMODULE_NOTIFY_EXPIRED as i32;
+        const EVICTED = REDISMODULE_NOTIFY_EVICTED as i32;
+        const STREAM = REDISMODULE_NOTIFY_STREAM as i32;
+        const ALL = REDISMODULE_NOTIFY_ALL as i32;
     }
 }
 

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -88,17 +88,17 @@ impl From<Status> for Result<(), &str> {
 
 #[cfg(feature = "experimental-api")]
 bitflags! {
-    pub struct NotifyEvent : i32 {
-        const GENERIC = REDISMODULE_NOTIFY_GENERIC as i32;
-        const STRING = REDISMODULE_NOTIFY_STRING as i32;
-        const LIST = REDISMODULE_NOTIFY_LIST as i32;
-        const SET = REDISMODULE_NOTIFY_SET as i32;
-        const HASH = REDISMODULE_NOTIFY_HASH as i32;
-        const ZSET = REDISMODULE_NOTIFY_ZSET as i32;
-        const EXPIRED = REDISMODULE_NOTIFY_EXPIRED as i32;
-        const EVICTED = REDISMODULE_NOTIFY_EVICTED as i32;
-        const STREAM = REDISMODULE_NOTIFY_STREAM as i32;
-        const ALL = REDISMODULE_NOTIFY_ALL as i32;
+    pub struct NotifyEvent : c_int {
+        const GENERIC = REDISMODULE_NOTIFY_GENERIC;
+        const STRING = REDISMODULE_NOTIFY_STRING;
+        const LIST = REDISMODULE_NOTIFY_LIST;
+        const SET = REDISMODULE_NOTIFY_SET;
+        const HASH = REDISMODULE_NOTIFY_HASH;
+        const ZSET = REDISMODULE_NOTIFY_ZSET;
+        const EXPIRED = REDISMODULE_NOTIFY_EXPIRED;
+        const EVICTED = REDISMODULE_NOTIFY_EVICTED;
+        const STREAM = REDISMODULE_NOTIFY_STREAM;
+        const ALL = REDISMODULE_NOTIFY_ALL;
     }
 }
 


### PR DESCRIPTION
Add optional `event_handlers` field to the `redis_module!` macro that enables
user to specify auto-registered keyspace event handlers.