### PR TITLE
Changed parse_call_reply to return a BulkString.

### DIFF
--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -120,7 +120,7 @@ impl Context {
                 Ok(RedisValue::Array(vec))
             }
             raw::ReplyType::Integer => Ok(RedisValue::Integer(raw::call_reply_integer(reply))),
-            raw::ReplyType::String => Ok(RedisValue::SimpleString(raw::call_reply_string(reply))),
+            raw::ReplyType::String => Ok(RedisValue::BulkString(raw::call_reply_string(reply))),
             raw::ReplyType::Null => Ok(RedisValue::Null),
         }
     }


### PR DESCRIPTION
This PR changes the parse_call_reply function to return a BulkString instead of af  SimpleString. 

The current implementation treats all string values, returned by calling a redis function within a module, as a SimpleString. This issue arises if you pass the the return value of call from your module.

The change i propose will treat string values returned from call as a BulkString as BulkStrings can contain line breaks, as the underlying string can contain line brakes