### PR TITLE
add Context::free_thread_safe_context()

### DIFF
--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -34,6 +34,11 @@ impl Context {
     }
 
     #[cfg(feature = "experimental-api")]
+    pub fn free_thread_safe_context(&self) {
+        unsafe { raw::RedisModule_FreeThreadSafeContext.unwrap()(self.ctx) };
+    }
+
+    #[cfg(feature = "experimental-api")]
     pub fn lock(&self) {
         unsafe { raw::RedisModule_ThreadSafeContextLock.unwrap()(self.ctx) };
     }


### PR DESCRIPTION
This PR creates a wrapper for `RedisModule_FreeThreadSafeContext` to the experimental API.

Without calling `RedisModule_FreeThreadSafeContext`, the thread safe contexts never seem to be freed.