### PR TITLE
Add idiomatic Rust API for ThreadSafeContext

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,11 @@ crate-type = ["cdylib"]
 required-features = ["experimental-api"]
 
 [[example]]
+name = "threads"
+crate-type = ["cdylib"]
+required-features = ["experimental-api"]
+
+[[example]]
 name = "data_type"
 crate-type = ["cdylib"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,11 @@ crate-type = ["cdylib"]
 required-features = ["experimental-api"]
 
 [[example]]
+name = "block"
+crate-type = ["cdylib"]
+required-features = ["experimental-api"]
+
+[[example]]
 name = "data_type"
 crate-type = ["cdylib"]
 

--- a/examples/block.rs
+++ b/examples/block.rs
@@ -1,0 +1,30 @@
+#[macro_use]
+extern crate redis_module;
+
+use redis_module::{Context, RedisError, RedisResult, RedisValue, ThreadSafeContext};
+use std::thread;
+use std::time::Duration;
+
+fn block(ctx: &Context, _args: Vec<String>) -> RedisResult {
+    let blocked_client = ctx.block_client();
+
+    thread::spawn(move || {
+        let thread_ctx = ThreadSafeContext::with_blocked_client(blocked_client);
+        thread::sleep(Duration::from_millis(1000));
+        thread_ctx.reply(Ok("42".into()));
+    });
+
+    // We will reply later, from the thread
+    Ok(RedisValue::NoReply)
+}
+
+//////////////////////////////////////////////////////
+
+redis_module! {
+    name: "block",
+    version: 1,
+    data_types: [],
+    commands: [
+        ["block", block, "", 0, 0, 0],
+    ],
+}

--- a/examples/threads.rs
+++ b/examples/threads.rs
@@ -1,0 +1,31 @@
+#[macro_use]
+extern crate redis_module;
+
+use bitflags::_core::time::Duration;
+use redis_module::{Context, RedisError, RedisResult, ThreadSafeContext};
+use std::thread;
+
+fn threads(_: &Context, _args: Vec<String>) -> RedisResult {
+    thread::spawn(move || {
+        let thread_ctx = ThreadSafeContext::new();
+
+        for _ in 0..2 {
+            let ctx = thread_ctx.lock();
+            ctx.call("INCR", &["threads"]).unwrap();
+            thread::sleep(Duration::from_millis(100));
+        }
+    });
+
+    Ok(().into())
+}
+
+//////////////////////////////////////////////////////
+
+redis_module! {
+    name: "threads",
+    version: 1,
+    data_types: [],
+    commands: [
+        ["threads", threads, "", 0, 0, 0],
+    ],
+}

--- a/src/context/blocked.rs
+++ b/src/context/blocked.rs
@@ -1,0 +1,34 @@
+use std::ptr;
+
+use crate::raw;
+use crate::Context;
+
+pub struct BlockedClient {
+    pub(crate) inner: *mut raw::RedisModuleBlockedClient,
+}
+
+// We need to be able to send the inner pointer to another thread
+unsafe impl Send for BlockedClient {}
+
+impl Drop for BlockedClient {
+    fn drop(&mut self) {
+        unsafe { raw::RedisModule_UnblockClient.unwrap()(self.inner, ptr::null_mut()) };
+    }
+}
+
+impl Context {
+    pub fn block_client(&self) -> BlockedClient {
+        let blocked_client = unsafe {
+            raw::RedisModule_BlockClient.unwrap()(
+                self.ctx, // ctx
+                None,     // reply_func
+                None,     // timeout_func
+                None, 0,
+            )
+        };
+
+        BlockedClient {
+            inner: blocked_client,
+        }
+    }
+}

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -13,6 +13,9 @@ mod timer;
 #[cfg(feature = "experimental-api")]
 pub(crate) mod thread_safe;
 
+#[cfg(feature = "experimental-api")]
+mod blocked;
+
 /// `Context` is a structure that's designed to give us a high-level interface to
 /// the Redis module API by abstracting away the raw C FFI calls.
 pub struct Context {

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -10,6 +10,9 @@ use crate::{RedisError, RedisResult, RedisString, RedisValue};
 #[cfg(feature = "experimental-api")]
 mod timer;
 
+#[cfg(feature = "experimental-api")]
+pub(crate) mod thread_safe;
+
 /// `Context` is a structure that's designed to give us a high-level interface to
 /// the Redis module API by abstracting away the raw C FFI calls.
 pub struct Context {
@@ -25,22 +28,6 @@ impl Context {
         Self {
             ctx: ptr::null_mut(),
         }
-    }
-
-    #[cfg(feature = "experimental-api")]
-    pub fn get_thread_safe_context() -> Self {
-        let ctx = unsafe { raw::RedisModule_GetThreadSafeContext.unwrap()(ptr::null_mut()) };
-        Context::new(ctx)
-    }
-
-    #[cfg(feature = "experimental-api")]
-    pub fn lock(&self) {
-        unsafe { raw::RedisModule_ThreadSafeContextLock.unwrap()(self.ctx) };
-    }
-
-    #[cfg(feature = "experimental-api")]
-    pub fn unlock(&self) {
-        unsafe { raw::RedisModule_ThreadSafeContextUnlock.unwrap()(self.ctx) };
     }
 
     pub fn log(&self, level: LogLevel, message: &str) {

--- a/src/context/thread_safe.rs
+++ b/src/context/thread_safe.rs
@@ -1,0 +1,45 @@
+use std::ops::Deref;
+use std::ptr;
+
+use crate::{raw, Context};
+
+pub struct ContextGuard {
+    ctx: Context,
+}
+
+impl Drop for ContextGuard {
+    fn drop(&mut self) {
+        unsafe { raw::RedisModule_ThreadSafeContextUnlock.unwrap()(self.ctx.ctx) };
+    }
+}
+
+impl Deref for ContextGuard {
+    type Target = Context;
+
+    fn deref(&self) -> &Self::Target {
+        &self.ctx
+    }
+}
+
+pub struct ThreadSafeContext {
+    pub(crate) ctx: *mut raw::RedisModuleCtx,
+}
+
+impl ThreadSafeContext {
+    pub fn new() -> ThreadSafeContext {
+        let ctx = unsafe { raw::RedisModule_GetThreadSafeContext.unwrap()(ptr::null_mut()) };
+        ThreadSafeContext { ctx }
+    }
+
+    pub fn lock(&self) -> ContextGuard {
+        unsafe { raw::RedisModule_ThreadSafeContextLock.unwrap()(self.ctx) };
+        let ctx = Context::new(self.ctx);
+        ContextGuard { ctx }
+    }
+}
+
+impl Drop for ThreadSafeContext {
+    fn drop(&mut self) {
+        unsafe { raw::RedisModule_FreeThreadSafeContext.unwrap()(self.ctx) };
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,7 @@ mod macros;
 mod context;
 mod key;
 
+pub use crate::context::thread_safe::ThreadSafeContext;
 pub use crate::context::Context;
 pub use crate::redismodule::*;
 


### PR DESCRIPTION
The API is similar to `std::sync::Mutex` in that it automatically handles unlocking and freeing, and makes it impossible to use it incorrectly.

For an example, see [examples/threads.rs](examples/threads.rs).