### PR TITLE
Add method for converting RedisString to &str

### DIFF
--- a/src/redismodule.rs
+++ b/src/redismodule.rs
@@ -3,6 +3,7 @@ use std::os::raw::{c_char, c_void};
 use std::slice;
 use std::str;
 use std::string::FromUtf8Error;
+use std::str::Utf8Error;
 
 pub use crate::raw;
 pub use crate::rediserror::RedisError;
@@ -82,7 +83,7 @@ impl RedisString {
         RedisString { ctx, inner }
     }
 
-    pub fn from_ptr<'a>(ptr: *const raw::RedisModuleString) -> Result<&'a str, str::Utf8Error> {
+    pub fn from_ptr<'a>(ptr: *const raw::RedisModuleString) -> Result<&'a str, Utf8Error> {
         let mut len: libc::size_t = 0;
         let bytes = unsafe { raw::RedisModule_StringPtrLen.unwrap()(ptr, &mut len) };
 
@@ -103,6 +104,10 @@ impl RedisString {
         let mut len: usize = 0;
         raw::string_ptr_len(self.inner, &mut len);
         len == 0
+    }
+
+    pub fn try_as_str(&self) -> Result<&str, Utf8Error> {
+        Self::from_ptr(self.inner)
     }
 }
 


### PR DESCRIPTION
This makes it more ergonomic to work with `RedisString` objects.