### PR TITLE
Fix usage of RedisModule_HashGet in raw::hash_get

### DIFF
--- a/src/raw.rs
+++ b/src/raw.rs
@@ -240,7 +240,7 @@ pub fn hash_get(key: *mut RedisModuleKey, field: &str) -> *mut RedisModuleString
             REDISMODULE_HASH_CFIELDS as i32,
             CString::new(field).unwrap().as_ptr(),
             &res,
-            0,
+            ptr::null::<c_char>(),
         );
     }
     res
@@ -253,7 +253,7 @@ pub fn hash_set(key: *mut RedisModuleKey, field: &str, value: *mut RedisModuleSt
             REDISMODULE_HASH_CFIELDS as i32,
             CString::new(field).unwrap().as_ptr(),
             value,
-            0,
+            ptr::null::<c_char>(),
         )
         .into()
     }


### PR DESCRIPTION
The Rust value "0" was being used as the terminating null pointer signalling the end of the variadic arguments. Unfortunately the type of this expression is i32, which creates a "read-past-the-end" condition in the calling C code. For calls to RedisModule_HashGet with a single argument this seems to usually work correctly, but trying to do the with 2 or more fields crashes with a segmentation fault.