### PR TITLE
Implement a conversion to RedisError from any type implementing the Error trait

### DIFF
--- a/src/rediserror.rs
+++ b/src/rediserror.rs
@@ -1,7 +1,4 @@
-use core::num::{ParseFloatError, ParseIntError};
 use std::fmt;
-use std::str::Utf8Error;
-use std::string::FromUtf8Error;
 
 #[derive(Debug)]
 pub enum RedisError {
@@ -16,38 +13,8 @@ impl RedisError {
     }
 }
 
-impl From<&'static str> for RedisError {
-    fn from(s: &'static str) -> Self {
-        RedisError::Str(s)
-    }
-}
-
-impl From<String> for RedisError {
-    fn from(s: String) -> Self {
-        RedisError::String(s)
-    }
-}
-
-impl From<ParseFloatError> for RedisError {
-    fn from(e: ParseFloatError) -> Self {
-        RedisError::String(e.to_string())
-    }
-}
-
-impl From<ParseIntError> for RedisError {
-    fn from(e: ParseIntError) -> Self {
-        RedisError::String(e.to_string())
-    }
-}
-
-impl From<FromUtf8Error> for RedisError {
-    fn from(e: FromUtf8Error) -> Self {
-        RedisError::String(e.to_string())
-    }
-}
-
-impl From<Utf8Error> for RedisError {
-    fn from(e: Utf8Error) -> Self {
+impl<T: std::error::Error> From<T> for RedisError {
+    fn from(e: T) -> Self {
         RedisError::String(e.to_string())
     }
 }


### PR DESCRIPTION
This obviates the need for the list of conversions from specific error types. Unfortunately
this also requires removing the conversions from `&'static str` and `String`, because future
implementations may cause conflicts.