### PR TITLE
Make the conversion of Error to RedisError conform to RESP conventions

### DIFF
--- a/src/rediserror.rs
+++ b/src/rediserror.rs
@@ -15,7 +15,7 @@ impl RedisError {
 
 impl<T: std::error::Error> From<T> for RedisError {
     fn from(e: T) -> Self {
-        RedisError::String(e.to_string())
+        RedisError::String(format!("ERR {}", e))
     }
 }
 


### PR DESCRIPTION
By convention the first word of the error is an uppercase string indicating the type of error.