### PR TITLE
Add infrastructure for exposing hash-multi-get functionality

### DIFF
--- a/src/key.rs
+++ b/src/key.rs
@@ -85,7 +85,7 @@ impl RedisKey {
         let val = if self.is_null() {
             None
         } else {
-            hash_get_key(self.ctx, self.key_inner, field)
+            hash_mget_key(self.ctx, self.key_inner, &[field])?.pop().unwrap()
         };
         Ok(val)
     }
@@ -150,7 +150,7 @@ impl RedisKeyWritable {
     }
 
     pub fn hash_get(&self, field: &str) -> Result<Option<RedisString>, RedisError> {
-        Ok(hash_get_key(self.ctx, self.key_inner, field))
+        Ok(hash_mget_key(self.ctx, self.key_inner, &[field])?.pop().unwrap())
     }
 
     pub fn set_expire(&self, expire: Duration) -> RedisResult {
@@ -246,17 +246,34 @@ fn read_key(key: *mut raw::RedisModuleKey) -> Result<String, Utf8Error> {
     )
 }
 
-fn hash_get_key(
-    ctx: *mut raw::RedisModuleCtx,
-    key: *mut raw::RedisModuleKey,
-    field: &str,
-) -> Option<RedisString> {
-    let res = raw::hash_get(key, field);
-    if res.is_null() {
-        None
-    } else {
-        Some(RedisString::new(ctx, res))
+/// Get an arbitrary number of hash fields from a key by batching calls
+/// to `raw::hash_get_multi`.
+pub fn hash_mget_key<T>(ctx: *mut raw::RedisModuleCtx,
+                        key: *mut raw::RedisModuleKey,
+                        fields: &[T])
+    -> Result<Vec<Option<RedisString>>, RedisError>
+    where T: Into<Vec<u8>> + Clone
+{
+    use crate::redisraw::bindings::RedisModuleString;
+    const BATCH_SIZE: usize = 12;
+
+    let mut values: Vec<Option<RedisString>> = Vec::with_capacity(fields.len());
+    let mut values_raw: [*mut RedisModuleString; BATCH_SIZE] =
+        [std::ptr::null_mut(); BATCH_SIZE];
+
+    for chunk_fields in fields.chunks(BATCH_SIZE) {
+        let mut chunk_values = &mut values_raw[..chunk_fields.len()];
+        raw::hash_get_multi(key, chunk_fields, &mut chunk_values)?;
+        values.extend(chunk_values.iter().map(|ptr|
+            if ptr.is_null() {
+                None
+            } else {
+                Some(RedisString::new(ctx, *ptr))
+            }
+        ));
     }
+
+    Ok(values)
 }
 
 fn to_raw_mode(mode: KeyMode) -> raw::KeyMode {

--- a/src/key.rs
+++ b/src/key.rs
@@ -85,7 +85,9 @@ impl RedisKey {
         let val = if self.is_null() {
             None
         } else {
-            hash_mget_key(self.ctx, self.key_inner, &[field])?.pop().unwrap()
+            hash_mget_key(self.ctx, self.key_inner, &[field])?
+                .pop()
+                .expect("hash_mget_key should return vector of same length as input")
         };
         Ok(val)
     }
@@ -150,7 +152,9 @@ impl RedisKeyWritable {
     }
 
     pub fn hash_get(&self, field: &str) -> Result<Option<RedisString>, RedisError> {
-        Ok(hash_mget_key(self.ctx, self.key_inner, &[field])?.pop().unwrap())
+        Ok(hash_mget_key(self.ctx, self.key_inner, &[field])?
+            .pop()
+            .expect("hash_mget_key should return vector of same length as input"))
     }
 
     pub fn set_expire(&self, expire: Duration) -> RedisResult {
@@ -248,29 +252,29 @@ fn read_key(key: *mut raw::RedisModuleKey) -> Result<String, Utf8Error> {
 
 /// Get an arbitrary number of hash fields from a key by batching calls
 /// to `raw::hash_get_multi`.
-pub fn hash_mget_key<T>(ctx: *mut raw::RedisModuleCtx,
-                        key: *mut raw::RedisModuleKey,
-                        fields: &[T])
-    -> Result<Vec<Option<RedisString>>, RedisError>
-    where T: Into<Vec<u8>> + Clone
+pub fn hash_mget_key<T>(
+    ctx: *mut raw::RedisModuleCtx,
+    key: *mut raw::RedisModuleKey,
+    fields: &[T],
+) -> Result<Vec<Option<RedisString>>, RedisError>
+where
+    T: Into<Vec<u8>> + Clone,
 {
-    use crate::redisraw::bindings::RedisModuleString;
     const BATCH_SIZE: usize = 12;
 
-    let mut values: Vec<Option<RedisString>> = Vec::with_capacity(fields.len());
-    let mut values_raw: [*mut RedisModuleString; BATCH_SIZE] =
-        [std::ptr::null_mut(); BATCH_SIZE];
+    let mut values = Vec::with_capacity(fields.len());
+    let mut values_raw = [std::ptr::null_mut(); BATCH_SIZE];
 
     for chunk_fields in fields.chunks(BATCH_SIZE) {
         let mut chunk_values = &mut values_raw[..chunk_fields.len()];
         raw::hash_get_multi(key, chunk_fields, &mut chunk_values)?;
-        values.extend(chunk_values.iter().map(|ptr|
+        values.extend(chunk_values.iter().map(|ptr| {
             if ptr.is_null() {
                 None
             } else {
                 Some(RedisString::new(ctx, *ptr))
             }
-        ));
+        }));
     }
 
     Ok(values)

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -271,6 +271,10 @@ where
         };
     }
 
+    // This convoluted code is necessary since Redis only exposes a varargs API for HashGet
+    // to modules. Unfortunately there's no straightforward or portable way of calling a
+    // a varargs function with a variable number of arguments that is determined at runtime.
+    // See also the following Redis ticket: https://github.com/redis/redis/issues/7860
     let res = Status::from(match fields.len() {
         0 => rm! {},
         1 => rm! {f!() v!()},

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -15,8 +15,8 @@ use std::ptr;
 use std::slice;
 
 pub use crate::redisraw::bindings::*;
-use crate::{RedisBuffer, RedisError};
 use crate::RedisString;
+use crate::{RedisBuffer, RedisError};
 
 bitflags! {
     pub struct KeyMode: c_int {
@@ -232,22 +232,25 @@ pub fn string_dma(key: *mut RedisModuleKey, len: *mut size_t, mode: KeyMode) -> 
     unsafe { RedisModule_StringDMA.unwrap()(key, len, mode.bits) }
 }
 
-pub fn hash_get_multi<T>(key: *mut RedisModuleKey, fields: &[T],
-                         values: &mut [*mut RedisModuleString])
-    -> Result<(), RedisError>
-    where T: Into<Vec<u8>> + Clone
+pub fn hash_get_multi<T>(
+    key: *mut RedisModuleKey,
+    fields: &[T],
+    values: &mut [*mut RedisModuleString],
+) -> Result<(), RedisError>
+where
+    T: Into<Vec<u8>> + Clone,
 {
     assert_eq!(fields.len(), values.len());
 
     let mut fi = fields.iter();
     let mut vi = values.iter_mut();
 
-    macro_rules! RM {
+    macro_rules! rm {
         () => { unsafe {
             RedisModule_HashGet.unwrap()(key, REDISMODULE_HASH_CFIELDS as i32,
                                          ptr::null::<c_char>())
         }};
-        ($($args:expr),*) => { unsafe {
+        ($($args:expr)*) => { unsafe {
             RedisModule_HashGet.unwrap()(
                 key, REDISMODULE_HASH_CFIELDS as i32,
                 $($args),*,
@@ -255,29 +258,51 @@ pub fn hash_get_multi<T>(key: *mut RedisModuleKey, fields: &[T],
             )
         }};
     }
-    macro_rules! f { () => { CString::new( (*fi.next().unwrap()).clone() ).unwrap().as_ptr() }; }
-    macro_rules! v { () => { vi.next().unwrap() }; }
+    macro_rules! f {
+        () => {
+            CString::new((*fi.next().unwrap()).clone())
+                .unwrap()
+                .as_ptr()
+        };
+    }
+    macro_rules! v {
+        () => {
+            vi.next().unwrap()
+        };
+    }
 
     let res = Status::from(match fields.len() {
-        0  => RM!(),
-        1  => RM!(f!(), v!()),
-        2  => RM!(f!(), v!(), f!(), v!()),
-        3  => RM!(f!(), v!(), f!(), v!(), f!(), v!()),
-        4  => RM!(f!(), v!(), f!(), v!(), f!(), v!(), f!(), v!()),
-        5  => RM!(f!(), v!(), f!(), v!(), f!(), v!(), f!(), v!(), f!(), v!()),
-        6  => RM!(f!(), v!(), f!(), v!(), f!(), v!(), f!(), v!(), f!(), v!(), f!(), v!()),
-        7  => RM!(f!(), v!(), f!(), v!(), f!(), v!(), f!(), v!(), f!(), v!(), f!(), v!(),
-                  f!(), v!()),
-        8  => RM!(f!(), v!(), f!(), v!(), f!(), v!(), f!(), v!(), f!(), v!(), f!(), v!(),
-                  f!(), v!(), f!(), v!()),
-        9  => RM!(f!(), v!(), f!(), v!(), f!(), v!(), f!(), v!(), f!(), v!(), f!(), v!(),
-                  f!(), v!(), f!(), v!(), f!(), v!()),
-        10 => RM!(f!(), v!(), f!(), v!(), f!(), v!(), f!(), v!(), f!(), v!(), f!(), v!(),
-                  f!(), v!(), f!(), v!(), f!(), v!(), f!(), v!()),
-        11 => RM!(f!(), v!(), f!(), v!(), f!(), v!(), f!(), v!(), f!(), v!(), f!(), v!(),
-                  f!(), v!(), f!(), v!(), f!(), v!(), f!(), v!(), f!(), v!()),
-        12 => RM!(f!(), v!(), f!(), v!(), f!(), v!(), f!(), v!(), f!(), v!(), f!(), v!(),
-                  f!(), v!(), f!(), v!(), f!(), v!(), f!(), v!(), f!(), v!(), f!(), v!()),
+        0 => rm! {},
+        1 => rm! {f!() v!()},
+        2 => rm! {f!() v!() f!() v!()},
+        3 => rm! {f!() v!() f!() v!() f!() v!()},
+        4 => rm! {f!() v!() f!() v!() f!() v!() f!() v!()},
+        5 => rm! {f!() v!() f!() v!() f!() v!() f!() v!() f!() v!()},
+        6 => rm! {f!() v!() f!() v!() f!() v!() f!() v!() f!() v!() f!() v!()},
+        7 => rm! {
+            f!() v!() f!() v!() f!() v!() f!() v!() f!() v!() f!() v!()
+            f!() v!()
+        },
+        8 => rm! {
+            f!() v!() f!() v!() f!() v!() f!() v!() f!() v!() f!() v!()
+            f!() v!() f!() v!()
+        },
+        9 => rm! {
+            f!() v!() f!() v!() f!() v!() f!() v!() f!() v!() f!() v!()
+            f!() v!() f!() v!() f!() v!()
+        },
+        10 => rm! {
+            f!() v!() f!() v!() f!() v!() f!() v!() f!() v!() f!() v!()
+            f!() v!() f!() v!() f!() v!() f!() v!()
+        },
+        11 => rm! {
+            f!() v!() f!() v!() f!() v!() f!() v!() f!() v!() f!() v!()
+            f!() v!() f!() v!() f!() v!() f!() v!() f!() v!()
+        },
+        12 => rm! {
+            f!() v!() f!() v!() f!() v!() f!() v!() f!() v!() f!() v!()
+            f!() v!() f!() v!() f!() v!() f!() v!() f!() v!() f!() v!()
+        },
         _ => panic!("Unsupported length"),
     });
 


### PR DESCRIPTION
This commit adds a `hash_get_multi` function in the `raw` module, and a private
`hash_mget_key` function in the `key` module. In the interests of avoiding code
duplication, the corresponding single-get functions are removed, and the public
RedisKey*.hash_get functionality is implemented via multi-get.

Public-facing RedisKey* methods for hash multi-get should be the subject of their
own commit.