### PR TITLE
Add API for context-less logging

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ bitflags = "1.2"
 libc = "0.2"
 enum-primitive-derive = "^0.1"
 num-traits = "^0.2"
+strum_macros = "0.19"
 #failure = "0.1"
 
 [build-dependencies]

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -1,6 +1,5 @@
 #[macro_use]
 extern crate redis_module;
-use redis_module::logging::*;
 
 use redis_module::{parse_integer, Context, RedisError, RedisResult};
 
@@ -8,8 +7,6 @@ fn hello_mul(_: &Context, args: Vec<String>) -> RedisResult {
     if args.len() < 2 {
         return Err(RedisError::WrongArity);
     }
-
-    log_warning("Oh hi there!");
 
     let nums = args
         .into_iter()

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -1,5 +1,6 @@
 #[macro_use]
 extern crate redis_module;
+use redis_module::logging::*;
 
 use redis_module::{parse_integer, Context, RedisError, RedisResult};
 
@@ -7,6 +8,8 @@ fn hello_mul(_: &Context, args: Vec<String>) -> RedisResult {
     if args.len() < 2 {
         return Err(RedisError::WrongArity);
     }
+
+    log_warning("Oh hi there!");
 
     let nums = args
         .into_iter()

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -34,13 +34,23 @@ impl Context {
     }
 
     pub fn log(&self, level: LogLevel, message: &str) {
-        let level = CString::new(format!("{:?}", level).to_lowercase()).unwrap();
-        let fmt = CString::new(message).unwrap();
-        unsafe { raw::RedisModule_Log.unwrap()(self.ctx, level.as_ptr(), fmt.as_ptr()) }
+        crate::logging::log_internal(self.ctx, level, message);
     }
 
     pub fn log_debug(&self, message: &str) {
+        self.log(LogLevel::Debug, message);
+    }
+
+    pub fn log_notice(&self, message: &str) {
         self.log(LogLevel::Notice, message);
+    }
+
+    pub fn log_verbose(&self, message: &str) {
+        self.log(LogLevel::Verbose, message);
+    }
+
+    pub fn log_warning(&self, message: &str) {
+        self.log(LogLevel::Warning, message);
     }
 
     pub fn auto_memory(&self) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,12 +3,6 @@
 use std::os::raw::c_char;
 use std::str::Utf8Error;
 
-#[macro_use]
-extern crate bitflags;
-#[macro_use]
-extern crate enum_primitive_derive;
-#[macro_use(AsRefStr)]
-extern crate strum_macros;
 extern crate num_traits;
 
 use libc::size_t;
@@ -17,16 +11,16 @@ pub mod alloc;
 pub mod error;
 pub mod native_types;
 pub mod raw;
+use strum_macros::AsRefStr;
 pub mod rediserror;
 mod redismodule;
 pub mod redisraw;
 pub mod redisvalue;
 
-#[macro_use]
-mod macros;
 mod context;
 mod key;
 pub mod logging;
+mod macros;
 
 #[cfg(feature = "experimental-api")]
 pub use crate::context::thread_safe::ThreadSafeContext;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 
 use std::os::raw::c_char;
 use std::str::Utf8Error;
+use strum_macros::AsRefStr;
 
 extern crate num_traits;
 
@@ -11,7 +12,6 @@ pub mod alloc;
 pub mod error;
 pub mod native_types;
 pub mod raw;
-use strum_macros::AsRefStr;
 pub mod rediserror;
 mod redismodule;
 pub mod redisraw;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,8 @@ use std::str::Utf8Error;
 extern crate bitflags;
 #[macro_use]
 extern crate enum_primitive_derive;
+#[macro_use(AsRefStr)]
+extern crate strum_macros;
 extern crate num_traits;
 
 use libc::size_t;
@@ -24,6 +26,7 @@ pub mod redisvalue;
 mod macros;
 mod context;
 mod key;
+pub mod logging;
 
 #[cfg(feature = "experimental-api")]
 pub use crate::context::thread_safe::ThreadSafeContext;
@@ -39,11 +42,15 @@ pub use crate::redismodule::*;
 static ALLOC: crate::alloc::RedisAlloc = crate::alloc::RedisAlloc;
 
 /// `LogLevel` is a level of logging to be specified with a Redis log directive.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, AsRefStr)]
 pub enum LogLevel {
+    #[strum(to_string = "debug")]
     Debug,
+    #[strum(to_string = "notice")]
     Notice,
+    #[strum(to_string = "verbose")]
     Verbose,
+    #[strum(to_string = "warning")]
     Warning,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,14 +37,11 @@ static ALLOC: crate::alloc::RedisAlloc = crate::alloc::RedisAlloc;
 
 /// `LogLevel` is a level of logging to be specified with a Redis log directive.
 #[derive(Clone, Copy, Debug, AsRefStr)]
+#[strum(serialize_all = "snake_case")]
 pub enum LogLevel {
-    #[strum(to_string = "debug")]
     Debug,
-    #[strum(to_string = "notice")]
     Notice,
-    #[strum(to_string = "verbose")]
     Verbose,
-    #[strum(to_string = "warning")]
     Warning,
 }
 

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,0 +1,40 @@
+use crate::LogLevel;
+use crate::raw;
+use std::ffi::CString;
+use std::ptr;
+
+pub(crate) fn log_internal(ctx: *mut raw::RedisModuleCtx, level: LogLevel, message: &str) {
+    if cfg!(feature = "test") {
+        return;
+    }
+    let level = CString::new(level.as_ref()).unwrap();
+    let fmt = CString::new(message).unwrap();
+    unsafe { raw::RedisModule_Log.unwrap()(ctx, level.as_ptr(), fmt.as_ptr()) }
+}
+
+/// Log a message to the Redis log with the given log level, without
+/// requiring a context. This prevents Redis from including the module
+/// name in the logged message.
+pub fn log(level: LogLevel, message: &str) {
+    log_internal(ptr::null_mut(), level, message);
+}
+
+/// Log a message to the Redis log with DEBUG log level.
+pub fn log_debug(message: &str) {
+    log(LogLevel::Debug, message);
+}
+
+/// Log a message to the Redis log with NOTICE log level.
+pub fn log_notice(message: &str) {
+    log(LogLevel::Debug, message);
+}
+
+/// Log a message to the Redis log with VERBOSE log level.
+pub fn log_verbose(message: &str) {
+    log(LogLevel::Debug, message);
+}
+
+/// Log a message to the Redis log with WARNING log level.
+pub fn log_warning(message: &str) {
+    log(LogLevel::Debug, message);
+}

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -8,6 +8,8 @@ extern crate enum_primitive_derive;
 extern crate libc;
 extern crate num_traits;
 
+use bitflags::bitflags;
+use enum_primitive_derive::Primitive;
 use libc::size_t;
 use num_traits::FromPrimitive;
 use std::ffi::CString;


### PR DESCRIPTION
- It is sometimes useful to log messages to the Redis logs from code that does not take a context
  object. The Redis modules API allows for this by specifying a NULL context, but the Rust wrapper
  previously prevented taking advantaged of this ability.
- Added a log_* method for each supported log level to the context object.
- Used `strum` to make translating the LogLevel enum to a string more efficient. This now uses
  static strings generated at compile-time, rather than allocating and formatting them dynamically
  at runtime on each log call.