### PR TITLE
Add support for running module unload code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,11 @@ required-features = ["experimental-api"]
 name = "data_type"
 crate-type = ["cdylib"]
 
+
+[[example]]
+name = "load_unload"
+crate-type = ["cdylib"]
+
 [dependencies]
 bitflags = "1.2"
 libc = "0.2"

--- a/examples/load_unload.rs
+++ b/examples/load_unload.rs
@@ -1,0 +1,48 @@
+#[macro_use]
+extern crate redis_module;
+
+use redis_module::{Context, LogLevel, RedisResult, raw};
+use std::os::raw::c_int;
+
+static mut GLOBAL_STATE: Option<String> = None;
+
+pub extern "C" fn init(ctx: *mut raw::RedisModuleCtx) -> c_int {
+    let ctx = Context::new(ctx);
+    let (before, after) = unsafe {
+        let before = GLOBAL_STATE.clone();
+        GLOBAL_STATE.replace("GLOBAL DATA".to_string());
+        let after = GLOBAL_STATE.clone();
+        (before, after)
+    };
+    ctx.log(LogLevel::Warning,
+            &format!("Update global state on LOAD. BEFORE: {:?}, AFTER: {:?}",
+                            before, after));
+
+    return raw::Status::Ok as c_int;
+}
+
+pub extern "C" fn deinit(ctx: *mut raw::RedisModuleCtx) -> c_int {
+    let ctx = Context::new(ctx);
+    let (before, after) = unsafe {
+        let before = GLOBAL_STATE.take();
+        let after = GLOBAL_STATE.clone();
+        (before, after)
+    };
+    ctx.log(LogLevel::Warning,
+            &format!("Update global state on UNLOAD. BEFORE: {:?}, AFTER: {:?}",
+                     before, after));
+
+    raw::Status::Ok as c_int
+}
+
+//////////////////////////////////////////////////////
+
+redis_module! {
+    name: "load_unload",
+    version: 1,
+    data_types: [],
+    init: init,
+    deinit: deinit,
+    commands: [],
+}
+


### PR DESCRIPTION
* Can now run de-init code, similarly to how init code can be specified for a module.
* Added an example module to demonstrate the functionality.
* Also, fixed paths in macros, so that they can compile regardless of which identifiers
  the caller has brought into scope.