### PR TITLE
Publicly export `BlockedClient` and `DetachedFromClient`

### DIFF
--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -14,7 +14,7 @@ mod timer;
 pub(crate) mod thread_safe;
 
 #[cfg(feature = "experimental-api")]
-mod blocked;
+pub(crate) mod blocked;
 
 /// `Context` is a structure that's designed to give us a high-level interface to
 /// the Redis module API by abstracting away the raw C FFI calls.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,9 @@ mod context;
 mod key;
 
 #[cfg(feature = "experimental-api")]
-pub use crate::context::thread_safe::ThreadSafeContext;
+pub use crate::context::blocked::BlockedClient;
+#[cfg(feature = "experimental-api")]
+pub use crate::context::thread_safe::{DetachedFromClient, ThreadSafeContext};
 
 pub use crate::context::Context;
 pub use crate::redismodule::*;


### PR DESCRIPTION
These are used in the public ThreadSafeContext API, but were not public. This limits users to using these types implicitly, and prevents them from specifying those types in function signatures.