### PR TITLE
Make `ThreadSafeContext` `Sync`

### DIFF
--- a/src/context/thread_safe.rs
+++ b/src/context/thread_safe.rs
@@ -31,6 +31,7 @@ pub struct ThreadSafeContext<B> {
 }
 
 unsafe impl<B> Send for ThreadSafeContext<B> {}
+unsafe impl<B> Sync for ThreadSafeContext<B> {}
 
 impl ThreadSafeContext<DetachedFromClient> {
     pub fn new() -> Self {


### PR DESCRIPTION
The locking used in it means it is perfectly safe to share references to the same context between threads, similarly to how it's safe to `Send`.