### PR TITLE
Fix `unused` compiler warning

### DIFF
--- a/src/context/thread_safe.rs
+++ b/src/context/thread_safe.rs
@@ -27,6 +27,9 @@ pub struct DetachedFromClient;
 
 pub struct ThreadSafeContext<B> {
     pub(crate) ctx: *mut raw::RedisModuleCtx,
+
+    /// This field is only used implicitly by `Drop`, so avoid a compiler warning
+    #[allow(dead_code)]
     blocked_client: B,
 }
 


### PR DESCRIPTION
The `struct` field is apparently never read, causing a compiler warning.
In fact, it's used in the `impl Drop` to call the Redis module API to unblock the client.
