### PR TITLE
Add user-facing hash_get_multi functionality to key objects

### DIFF
--- a/examples/data_type.rs
+++ b/examples/data_type.rs
@@ -2,7 +2,7 @@
 extern crate redis_module;
 
 use redis_module::native_types::RedisType;
-use redis_module::{raw, Context, NextArg, RedisError, RedisResult};
+use redis_module::{raw, Context, NextArg, RedisResult};
 use std::os::raw::c_void;
 
 #[derive(Debug)]

--- a/examples/load_unload.rs
+++ b/examples/load_unload.rs
@@ -1,7 +1,7 @@
 #[macro_use]
 extern crate redis_module;
 
-use redis_module::{Context, LogLevel, RedisResult, raw};
+use redis_module::{raw, Context, LogLevel};
 use std::os::raw::c_int;
 
 static mut GLOBAL_STATE: Option<String> = None;
@@ -14,9 +14,13 @@ pub extern "C" fn init(ctx: *mut raw::RedisModuleCtx) -> c_int {
         let after = GLOBAL_STATE.clone();
         (before, after)
     };
-    ctx.log(LogLevel::Warning,
-            &format!("Update global state on LOAD. BEFORE: {:?}, AFTER: {:?}",
-                            before, after));
+    ctx.log(
+        LogLevel::Warning,
+        &format!(
+            "Update global state on LOAD. BEFORE: {:?}, AFTER: {:?}",
+            before, after
+        ),
+    );
 
     return raw::Status::Ok as c_int;
 }
@@ -28,9 +32,13 @@ pub extern "C" fn deinit(ctx: *mut raw::RedisModuleCtx) -> c_int {
         let after = GLOBAL_STATE.clone();
         (before, after)
     };
-    ctx.log(LogLevel::Warning,
-            &format!("Update global state on UNLOAD. BEFORE: {:?}, AFTER: {:?}",
-                     before, after));
+    ctx.log(
+        LogLevel::Warning,
+        &format!(
+            "Update global state on UNLOAD. BEFORE: {:?}, AFTER: {:?}",
+            before, after
+        ),
+    );
 
     raw::Status::Ok as c_int
 }
@@ -45,4 +53,3 @@ redis_module! {
     deinit: deinit,
     commands: [],
 }
-

--- a/src/key.rs
+++ b/src/key.rs
@@ -275,6 +275,15 @@ where
     /// Convert the results into any list-like collection. The field values in the collection
     /// appear in the same order as that in which the field names were provided to the multi-get
     /// call. Fields which do not exist are set to `None`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let key = ctx.open_key(keyname);
+    /// let v: Vec<Option<String>> = key
+    ///     .hash_get_multi(&["some_field_1", "some_field_2"])?
+    ///     .into_list();
+    /// ```
     pub fn into_list<B>(self) -> B
     where
         B: FromIterator<Option<String>>,
@@ -287,6 +296,17 @@ where
 
     /// Convert the results into any map-like collection. Only existing fields will
     /// be included in the collection.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::collections::HashMap;
+    ///
+    /// let key = ctx.open_key(keyname);
+    /// let v: HashMap<&str, String> = key
+    ///     .hash_get_multi(&["some_field_1", "some_field_2"])?
+    ///     .into_map();
+    /// ```
     pub fn into_map<B>(self) -> B
     where
         B: FromIterator<(T, String)>,

--- a/src/key.rs
+++ b/src/key.rs
@@ -325,7 +325,7 @@ fn read_key(key: *mut raw::RedisModuleKey) -> Result<String, Utf8Error> {
 
 /// Get an arbitrary number of hash fields from a key by batching calls
 /// to `raw::hash_get_multi`.
-pub fn hash_mget_key<T>(
+fn hash_mget_key<T>(
     ctx: *mut raw::RedisModuleCtx,
     key: *mut raw::RedisModuleKey,
     fields: &[T],


### PR DESCRIPTION
Generic result type permits obtaining multi-get results in any list- or map-like Rust collection.