### PR TITLE
Provide an IntoIterator for the multi-get results

### DIFF
--- a/src/redismodule.rs
+++ b/src/redismodule.rs
@@ -129,6 +129,12 @@ impl Drop for RedisString {
     }
 }
 
+impl From<RedisString> for String {
+    fn from(rs: RedisString) -> Self {
+        rs.into_string_lossy()
+    }
+}
+
 ///////////////////////////////////////////////////
 
 #[derive(Debug)]


### PR DESCRIPTION
This is both more idiomatic and more flexible than the previous `into_list`/`into_map`. It is now possible to both immediately collect the results into the user's choice of collection, and to perform further manipulations on the results via iterator methods without materializing them into an intermediate collection and incurring allocation costs.

Since the resulting iterator iterates of (key,value) pairs, this comes at the small cost of needing to explicitly `map` the results to collect them into a vector of field-values only.