### PR TITLE
Allow access to raw context and RedisKey

### DIFF
--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -209,4 +209,8 @@ impl Context {
     pub fn create_string(&self, s: &str) -> RedisString {
         RedisString::create(self.ctx, s)
     }
+
+    pub fn get_raw(&self) -> *mut raw::RedisModuleCtx {
+        return self.ctx;
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@ pub mod redisraw;
 pub mod redisvalue;
 
 mod context;
-mod key;
+pub mod key;
 pub mod logging;
 mod macros;
 


### PR DESCRIPTION
This changes allows 2 things:
1. Allow other modules dev that want to get a raw pointer to the Context, this is helpful for those who use bindgen with the C module to cast between the generator code.
2. Make `key` public to allow importing and using `RedisKey` struct in other higher level structs.