### PR TITLE
Make init/deinit callbacks use high-level API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ Cargo.lock
 # IntelliJ
 .idea
 src/redisraw/bindings.rs
+
+# VS Code
+.vscode

--- a/examples/load_unload.rs
+++ b/examples/load_unload.rs
@@ -1,13 +1,11 @@
 #[macro_use]
 extern crate redis_module;
 
-use redis_module::{raw, Context, LogLevel};
-use std::os::raw::c_int;
+use redis_module::{Context, LogLevel, Status};
 
 static mut GLOBAL_STATE: Option<String> = None;
 
-pub extern "C" fn init(ctx: *mut raw::RedisModuleCtx) -> c_int {
-    let ctx = Context::new(ctx);
+fn init(ctx: &Context) -> Status {
     let (before, after) = unsafe {
         let before = GLOBAL_STATE.clone();
         GLOBAL_STATE.replace("GLOBAL DATA".to_string());
@@ -22,11 +20,10 @@ pub extern "C" fn init(ctx: *mut raw::RedisModuleCtx) -> c_int {
         ),
     );
 
-    return raw::Status::Ok as c_int;
+    Status::Ok
 }
 
-pub extern "C" fn deinit(ctx: *mut raw::RedisModuleCtx) -> c_int {
-    let ctx = Context::new(ctx);
+fn deinit(ctx: &Context) -> Status {
     let (before, after) = unsafe {
         let before = GLOBAL_STATE.take();
         let after = GLOBAL_STATE.clone();
@@ -40,7 +37,7 @@ pub extern "C" fn deinit(ctx: *mut raw::RedisModuleCtx) -> c_int {
         ),
     );
 
-    raw::Status::Ok as c_int
+    Status::Ok
 }
 
 //////////////////////////////////////////////////////

--- a/examples/load_unload.rs
+++ b/examples/load_unload.rs
@@ -5,10 +5,10 @@ use redis_module::{Context, LogLevel, Status};
 
 static mut GLOBAL_STATE: Option<String> = None;
 
-fn init(ctx: &Context) -> Status {
+fn init(ctx: &Context, args: &Vec<String>) -> Status {
     let (before, after) = unsafe {
         let before = GLOBAL_STATE.clone();
-        GLOBAL_STATE.replace("GLOBAL DATA".to_string());
+        GLOBAL_STATE.replace(format!("Args passed: {}", args.join(", ")));
         let after = GLOBAL_STATE.clone();
         (before, after)
     };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,7 @@ pub use crate::context::thread_safe::{DetachedFromClient, ThreadSafeContext};
 #[cfg(feature = "experimental-api")]
 pub use crate::raw::NotifyEvent;
 
+pub use crate::raw::Status;
 pub use crate::context::Context;
 pub use crate::redismodule::*;
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -18,19 +18,7 @@ macro_rules! redis_command {
         ) -> c_int {
             let context = $crate::Context::new(ctx);
 
-            let args_decoded: Result<Vec<_>, $crate::RedisError> =
-                unsafe { slice::from_raw_parts(argv, argc as usize) }
-                    .into_iter()
-                    .map(|&arg| {
-                        $crate::RedisString::from_ptr(arg)
-                            .map(|v| v.to_owned())
-                            .map_err(|_| {
-                                $crate::RedisError::Str("UTF8 encoding error in handler args")
-                            })
-                    })
-                    .collect();
-
-            let response = args_decoded
+            let response = $crate::decode_args(argv, argc)
                 .map(|args| $command_handler(&context, args))
                 .unwrap_or_else(|e| Err(e));
 
@@ -127,12 +115,11 @@ macro_rules! redis_module {
         #[allow(non_snake_case)]
         pub extern "C" fn RedisModule_OnLoad(
             ctx: *mut $crate::raw::RedisModuleCtx,
-            _argv: *mut *mut $crate::raw::RedisModuleString,
-            _argc: std::os::raw::c_int,
+            argv: *mut *mut $crate::raw::RedisModuleString,
+            argc: std::os::raw::c_int,
         ) -> std::os::raw::c_int {
             use std::os::raw::{c_int, c_char};
             use std::ffi::{CString, CStr};
-            use std::slice;
 
             use $crate::raw;
             use $crate::RedisString;
@@ -159,8 +146,12 @@ macro_rules! redis_module {
             ) } == raw::Status::Err as c_int { return raw::Status::Err as c_int; }
 
             let context = $crate::Context::new(ctx);
+            let args = $crate::decode_args(argv, argc);
+
+            if args.is_err() { return raw::Status::Err as c_int }
+
             $(
-                if $init_func(&context) == $crate::Status::Err {
+                if $init_func(&context, &args.unwrap()) == $crate::Status::Err {
                     return $crate::Status::Err as c_int;
                 }
             )*

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -158,9 +158,10 @@ macro_rules! redis_module {
                 raw::REDISMODULE_APIVER_1 as c_int,
             ) } == raw::Status::Err as c_int { return raw::Status::Err as c_int; }
 
+            let context = $crate::Context::new(ctx);
             $(
-                if $init_func(ctx) == raw::Status::Err as c_int {
-                    return raw::Status::Err as c_int;
+                if $init_func(&context) == $crate::Status::Err {
+                    return $crate::Status::Err as c_int;
                 }
             )*
 
@@ -188,13 +189,16 @@ macro_rules! redis_module {
         pub extern "C" fn RedisModule_OnUnload(
             ctx: *mut $crate::raw::RedisModuleCtx
         ) -> std::os::raw::c_int {
+            use std::os::raw::c_int;
+
+            let context = $crate::Context::new(ctx);
             $(
-                if $deinit_func(ctx) == raw::Status::Err as c_int {
-                    return $crate::raw::Status::Err as c_int;
+                if $deinit_func(&context) == $crate::Status::Err {
+                    return $crate::Status::Err as c_int;
                 }
             )*
 
-            $crate::raw::Status::Ok as std::os::raw::c_int
+            $crate::raw::Status::Ok as c_int
         }
     }
 }


### PR DESCRIPTION
Both the `commands` and `event_handlers` macro callbacks are written in terms of the high-level API. I.e. user gets passed a parameter a "high-level" `Context` (instead of `raw::RedisModuleCtx` pointer), args converted to strings... return values (when necessary) properly handled .etc. `init` and `deinit` appear to be exceptions to this because they require user to write the callbacks in terms of `raw::` types and manually casting statuses to `c_int`... This PR attempts to achieve full consistency by making the init/deinit callback use "high-level" types (though at a cost of a breaking change) so modules will no longer have to mix-and-match "high-level" and "raw" terminology for various callbacks.

* Now a constructed Context reference is passed to init/deinit callbacks
  (instead of former raw::RedisModuleCtx) and they are expected to
  return Status (Ok|Err) instead of c_int.
* Exposed raw::State as $crate::State to make the init/deint not depend
  on any raw:: types.