### PR TITLE
Allow the use of NextArg on Iter<&str> as well as Iter<String>

### DIFF
--- a/src/redismodule.rs
+++ b/src/redismodule.rs
@@ -14,7 +14,7 @@ pub type RedisResult = Result<RedisValue, RedisError>;
 pub const REDIS_OK: RedisResult = Ok(RedisValue::SimpleStringStatic("OK"));
 pub const TYPE_METHOD_VERSION: u64 = raw::REDISMODULE_TYPE_METHOD_VERSION as u64;
 
-pub trait NextArg: Iterator {
+pub trait NextArg {
     fn next_string(&mut self) -> Result<String, RedisError>;
     fn next_i64(&mut self) -> Result<i64, RedisError>;
     fn next_u64(&mut self) -> Result<u64, RedisError>;
@@ -22,24 +22,30 @@ pub trait NextArg: Iterator {
     fn done(&mut self) -> Result<(), RedisError>;
 }
 
-impl<T: Iterator<Item = String>> NextArg for T {
+impl<S, T> NextArg for T
+where
+    T: Iterator<Item = S>,
+    S: AsRef<str>,
+{
     fn next_string(&mut self) -> Result<String, RedisError> {
-        self.next().map_or(Err(RedisError::WrongArity), Result::Ok)
+        self.next()
+            .map_or(Err(RedisError::WrongArity), |v| Ok(v.as_ref().to_string()))
     }
 
     fn next_i64(&mut self) -> Result<i64, RedisError> {
         self.next()
-            .map_or(Err(RedisError::WrongArity), |v| parse_integer(&v))
+            .map_or(Err(RedisError::WrongArity), |v| parse_integer(v.as_ref()))
     }
 
     fn next_u64(&mut self) -> Result<u64, RedisError> {
-        self.next()
-            .map_or(Err(RedisError::WrongArity), |v| parse_unsigned_integer(&v))
+        self.next().map_or(Err(RedisError::WrongArity), |v| {
+            parse_unsigned_integer(v.as_ref())
+        })
     }
 
     fn next_f64(&mut self) -> Result<f64, RedisError> {
         self.next()
-            .map_or(Err(RedisError::WrongArity), |v| parse_float(&v))
+            .map_or(Err(RedisError::WrongArity), |v| parse_float(v.as_ref()))
     }
 
     /// Return an error if there are any more arguments
@@ -61,7 +67,6 @@ pub fn decode_args(
         })
         .collect()
 }
-
 
 pub fn parse_unsigned_integer(arg: &str) -> Result<u64, RedisError> {
     arg.parse()


### PR DESCRIPTION
This makes it easier to write tests that naturally provide a `Vec<&str>` instead of a `Vec<String>` which requires manually calling `to_string()` on all items.

The disadvantage of this change is that unlike the previous approach, if we already have an owned `String`, we clone it anyway. 

There doesn't seem to be a way to get both advantages at the same time.