### PR TITLE
Add integration test infrastructure for example modules

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,10 @@ num-traits = "^0.2"
 strum_macros = "0.19"
 #failure = "0.1"
 
+[dev-dependencies]
+anyhow = "1.0.38"
+redis = "0.20.0"
+
 [build-dependencies]
 bindgen = "0.57"
 cc = "1.0"

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,0 +1,18 @@
+mod utils;
+
+use anyhow::Result;
+use utils::{get_redis_connection, prepare_dirs, start_redis_server_with_module};
+
+#[test]
+#[ignore] // test will be run explicitly by a script
+fn test_hello() -> Result<()> {
+    prepare_dirs()?;
+
+    let _guards = vec![start_redis_server_with_module("hello")?];
+    let mut con = get_redis_connection()?;
+
+    let res: Vec<i32> = redis::cmd("hello.mul").arg(&[3, 4]).query(&mut con)?;
+    assert_eq!(res, vec![3, 4, 12]);
+
+    Ok(())
+}

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -1,0 +1,108 @@
+use anyhow::{Context, Result};
+
+use redis::Connection;
+use std::fs;
+use std::io::ErrorKind;
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::Duration;
+
+const LOG_DIR: &str = "tests/log";
+const REDIS_PORT: u16 = 6666;
+
+/// Ensure child process is killed both on normal exit and when panicking due to a failed test.
+pub struct ChildGuard {
+    name: &'static str,
+    child: std::process::Child,
+}
+
+impl Drop for ChildGuard {
+    fn drop(&mut self) {
+        if let Err(e) = self.child.kill() {
+            println!("Could not kill {}: {}", self.name, e)
+        }
+        if let Err(e) = self.child.wait() {
+            println!("Could not wait for {}: {}", self.name, e)
+        }
+    }
+}
+
+pub fn prepare_dirs() -> Result<()> {
+    let dirs = &[LOG_DIR];
+
+    for dir in dirs {
+        remove_tree(dir).context(dir)?;
+        fs::create_dir(dir).context(dir)?;
+    }
+
+    Ok(())
+}
+
+fn remove_tree(dir: &str) -> Result<()> {
+    match fs::remove_dir_all(dir) {
+        Err(e) if e.kind() == ErrorKind::NotFound => Ok(()),
+        res => res.with_context(|| dir.to_string()),
+    }
+}
+
+pub fn start_redis_server_with_module(module_name: &str) -> Result<ChildGuard> {
+    let extension = if cfg!(target_os = "macos") {
+        "dylib"
+    } else {
+        "so"
+    };
+
+    let module_path: PathBuf = [
+        std::env::current_dir()?,
+        PathBuf::from(format!(
+            "target/debug/examples/lib{}.{}",
+            module_name, extension
+        )),
+    ]
+    .iter()
+    .collect();
+
+    assert!(fs::metadata(&module_path)
+        .with_context(|| format!("Loading redis module: {}", module_path.display()))?
+        .is_file());
+
+    let module_path = format!("{}", module_path.display());
+    let port = REDIS_PORT.to_string();
+
+    #[rustfmt::skip]
+        let args = &[
+        "--port", port.as_str(),
+        "--loadmodule", module_path.as_str(),
+        "--dir", LOG_DIR,
+        "--logfile", "redis.log",
+    ];
+
+    let redis_server = Command::new("redis-server")
+        .args(args)
+        .spawn()
+        .map(|c| ChildGuard {
+            name: "redis_server",
+            child: c,
+        })?;
+
+    Ok(redis_server)
+}
+
+// Get connection to Redis
+pub fn get_redis_connection() -> Result<Connection> {
+    let client = redis::Client::open(format!("redis://127.0.0.1:{}/", REDIS_PORT))?;
+    loop {
+        let res = client.get_connection();
+        match res {
+            Ok(con) => return Ok(con),
+            Err(e) => {
+                if e.is_connection_refusal() {
+                    // Redis not ready yet, sleep and retry
+                    std::thread::sleep(Duration::from_millis(50));
+                } else {
+                    Err(e)?;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
As discussed in #135, this PR adds infrastructure for integrations tests that can run the example modules inside Redis and perform tests against them.

The infra takes care of starting `redis-server` and shutting it down.