### PR TITLE
WIP open_with_redis_string does not take ownership of the RedisModuleString

### DIFF
--- a/src/key.rs
+++ b/src/key.rs
@@ -33,7 +33,7 @@ pub enum KeyMode {
 pub struct RedisKey {
     ctx: *mut raw::RedisModuleCtx,
     key_inner: *mut raw::RedisModuleKey,
-    key_str: RedisString,
+    key_str: Option<RedisString>,
 }
 
 impl RedisKey {
@@ -41,9 +41,9 @@ impl RedisKey {
         let key_str = RedisString::create(ctx, key);
         let key_inner = raw::open_key(ctx, key_str.inner, to_raw_mode(KeyMode::Read));
         RedisKey {
-            ctx,
-            key_inner,
-            key_str,
+            ctx: ctx,
+            key_inner: key_inner,
+            key_str: Some(key_str),
         }
     }
 
@@ -133,7 +133,7 @@ pub struct RedisKeyWritable {
     // This field is needed on the struct so that its Drop implementation gets
     // called when it goes out of scope.
     #[allow(dead_code)]
-    key_str: RedisString,
+    key_str: Option<RedisString>,
 }
 
 impl RedisKeyWritable {
@@ -141,9 +141,9 @@ impl RedisKeyWritable {
         let key_str = RedisString::create(ctx, key);
         let key_inner = raw::open_key(ctx, key_str.inner, to_raw_mode(KeyMode::ReadWrite));
         RedisKeyWritable {
-            ctx,
-            key_inner,
-            key_str,
+            ctx: ctx,
+            key_inner: key_inner,
+            key_str: Some(key_str),
         }
     }
 
@@ -243,12 +243,11 @@ impl RedisKeyWritable {
         ctx: *mut raw::RedisModuleCtx,
         string: *mut raw::RedisModuleString,
     ) -> RedisKeyWritable {
-        let key_str = RedisString::create_from_redis_string(ctx, string);
-        let key_inner = raw::open_key(ctx, key_str.inner, to_raw_mode(KeyMode::ReadWrite));
+        let key_inner = raw::open_key(ctx, string, to_raw_mode(KeyMode::ReadWrite));
         RedisKeyWritable {
-            ctx,
-            key_inner,
-            key_str,
+            ctx: ctx,
+            key_inner: key_inner,
+            key_str: None,
         }
     }
 

--- a/src/redismodule.rs
+++ b/src/redismodule.rs
@@ -103,16 +103,6 @@ impl RedisString {
         RedisString { ctx, inner }
     }
 
-    pub fn create_from_redis_string(
-        ctx: *mut raw::RedisModuleCtx,
-        redis_string: *mut raw::RedisModuleString,
-    ) -> RedisString {
-        RedisString {
-            ctx,
-            inner: redis_string,
-        }
-    }
-
     pub fn from_ptr<'a>(ptr: *const raw::RedisModuleString) -> Result<&'a str, Utf8Error> {
         let mut len: libc::size_t = 0;
         let bytes = unsafe { raw::RedisModule_StringPtrLen.unwrap()(ptr, &mut len) };


### PR DESCRIPTION
A better fix instead of commit 57f10c2 in RedisJSON
"WIP Do not take ownership of RedisModuleString passed to JSONAPI_openKey"