### PR TITLE
 Mark export_shared_api with missing experimental-api feature 

### DIFF
--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -223,16 +223,13 @@ impl Context {
         self.ctx
     }
 
+    #[cfg(feature = "experimental-api")]
     pub fn export_shared_api(
         &self,
         func: *const ::std::os::raw::c_void,
         name: *const ::std::os::raw::c_char,
     ) {
-        raw::export_shared_api(
-            self.ctx,
-            func,
-            name,
-        );
+        raw::export_shared_api(self.ctx, func, name);
     }
 
     #[cfg(feature = "experimental-api")]

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -494,6 +494,7 @@ pub fn subscribe_to_server_event(
     unsafe { RedisModule_SubscribeToServerEvent.unwrap()(ctx, event, callback).into() }
 }
 
+#[cfg(feature = "experimental-api")]
 pub fn export_shared_api(
     ctx: *mut RedisModuleCtx,
     func: *const ::std::os::raw::c_void,
@@ -521,7 +522,6 @@ pub fn notify_keyspace_event(
         .into()
     }
 }
-
 
 #[cfg(feature = "experimental-api")]
 pub fn get_keyspace_events() -> NotifyEvent {


### PR DESCRIPTION
The new `export_shared_api` function wraps the underlying `RedisModule_ExportSharedAPI` which is conditionally compiled with `REDISMODULE_EXPERIMENTAL_API`.

Therefore, it should be annotated with `#[cfg(feature = "experimental-api")]` so that code that is built without this feature won't try to compile this function.