### PR TITLE
timer callback data is static

### DIFF
--- a/src/context/timer.rs
+++ b/src/context/timer.rs
@@ -20,7 +20,12 @@ impl Context {
     /// This function takes ownership of the provided data, and transfers it to Redis.
     /// The callback will get the original data back in a type safe manner.
     /// When the callback is done, the data will be dropped.
-    pub fn create_timer<F, T>(&self, period: Duration, callback: F, data: T) -> RedisModuleTimerID
+    pub fn create_timer<F, T: 'static>(
+        &self,
+        period: Duration,
+        callback: F,
+        data: T,
+    ) -> RedisModuleTimerID
     where
         F: FnOnce(&Context, T),
     {


### PR DESCRIPTION
## Motivation:
`Context::create_timer()` accepts `data` without static lifetime bounds. This results in runtime errors, if data passed was dropped before callback executes.

Without static bounds on `data`, the following code will panic at runtime(error below code section). But with static bounds, such things will be caught at compile time.

Modified `example/timer.rs`:

```rust
#[macro_use]
extern crate redis_module;

use redis_module::{Context, NextArg, RedisResult};
use std::time::Duration;

fn callback(ctx: &Context, data: String) {
    ctx.log_debug(format!("[callback]: {}", data).as_str());
}

type MyData = String;

fn timer_create(ctx: &Context, args: Vec<String>) -> RedisResult {
    let mut args = args.into_iter().skip(1);
    let duration = args.next_i64()?;
    let data: MyData = args.next_string()?;

    let timer_id = ctx.create_timer(Duration::from_millis(duration as u64), callback, data);

    return Ok(format!("{}", timer_id).into());
}

fn timer_info(ctx: &Context, args: Vec<String>) -> RedisResult {
    let mut args = args.into_iter().skip(1);
    let timer_id = args.next_u64()?;

    let (remaining, data): (_, &MyData) = ctx.get_timer_info(timer_id)?;
    let reply = format!("Remaining: {:?}, data: {:?}", remaining, data);

    return Ok(reply.into());
}

fn timer_stop(ctx: &Context, args: Vec<String>) -> RedisResult {
    let mut args = args.into_iter().skip(1);
    let timer_id = args.next_u64()?;

    let data: MyData = ctx.stop_timer(timer_id)?;
    let reply = format!("Data: {:?}", data);

    return Ok(reply.into());
}

//////////////////////////////////////////////////////

redis_module! {
    name: "timer",
    version: 1,
    data_types: [],
    commands: [
        ["timer.create", timer_create, "", 0, 0, 0],
        ["timer.info", timer_info, "", 0, 0, 0],
        ["timer.stop", timer_stop, "", 0, 0, 0],
    ],
}
```
### Runtime error:
```bash
1066840:M 07 Jun 2021 17:41:05.762 * DB loaded from disk: 0.000 seconds
1066840:M 07 Jun 2021 17:41:05.762 * Ready to accept connections
1066840:M 07 Jun 2021 17:41:05.763 - DB 0: 11 keys (0 volatile) in 16 slots HT.
1066840:M 07 Jun 2021 17:41:05.763 . 0 clients connected (0 replicas), 818160 bytes in use
1066840:M 07 Jun 2021 17:41:06.063 - Accepted 127.0.0.1:34594
1066840:M 07 Jun 2021 17:41:08.064 # <timer> executing [callback]: test
thread '<unnamed>' panicked at 'called `Result::unwrap()` on an `Err` value: NulError(31, [114, 99, 114, 118, 117, 121, 105, 110, 104, 32, 118, 115, 108, 108, 98, 115, 118, 107, 32, 91, 99, 97, 108, 108, 98, 97, 99, 107, 93, 58, 32, 0, 97, 114, 110])', src/logging.rs:11:37
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
fatal runtime error: failed to initiate panic, error 5
```

---
Thanks for the great library, I'm having a lot of fun playing around with it :)