### PR TITLE
Add next_str to NextArg

### DIFF
--- a/src/redismodule.rs
+++ b/src/redismodule.rs
@@ -46,7 +46,7 @@ where
     #[inline]
     fn next_str<'a>(&mut self) -> Result<&'a str, RedisError> {
         self.next()
-        .map_or(Err(RedisError::WrongArity), |v| v.try_as_str())
+            .map_or(Err(RedisError::WrongArity), |v| v.try_as_str())
     }
 
     #[inline]


### PR DESCRIPTION
1. Add `next_str` to NextArg
2. mark all NextArg as `[#inline]`