### PR TITLE
`impl {Eq, Ord, Hash} for RedisString`

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -75,13 +75,13 @@ impl GenericError {
     }
 }
 
-impl<'a> Display for GenericError {
+impl Display for GenericError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "Store error: {}", self.message)
     }
 }
 
-impl<'a> error::Error for GenericError {
+impl error::Error for GenericError {
     fn description(&self) -> &str {
         self.message.as_str()
     }

--- a/src/include/redismodule.h
+++ b/src/include/redismodule.h
@@ -714,7 +714,7 @@ REDISMODULE_API void (*RedisModule_LatencyAddSample)(const char *event, mstime_t
 REDISMODULE_API int (*RedisModule_StringAppendBuffer)(RedisModuleCtx *ctx, RedisModuleString *str, const char *buf, size_t len) REDISMODULE_ATTR;
 REDISMODULE_API void (*RedisModule_RetainString)(RedisModuleCtx *ctx, RedisModuleString *str) REDISMODULE_ATTR;
 REDISMODULE_API RedisModuleString * (*RedisModule_HoldString)(RedisModuleCtx *ctx, RedisModuleString *str) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_StringCompare)(RedisModuleString *a, RedisModuleString *b) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_StringCompare)(const RedisModuleString *a, const RedisModuleString *b) REDISMODULE_ATTR;
 REDISMODULE_API RedisModuleCtx * (*RedisModule_GetContextFromIO)(RedisModuleIO *io) REDISMODULE_ATTR;
 REDISMODULE_API const RedisModuleString * (*RedisModule_GetKeyNameFromIO)(RedisModuleIO *io) REDISMODULE_ATTR;
 REDISMODULE_API const RedisModuleString * (*RedisModule_GetKeyNameFromModuleKey)(RedisModuleKey *key) REDISMODULE_ATTR;

--- a/src/key.rs
+++ b/src/key.rs
@@ -24,7 +24,7 @@ use crate::RedisString;
 /// by explicitly freeing them when you're done. This can be a risky prospect,
 /// especially with mechanics like Rust's `?` operator, so we ensure fault-free
 /// operation through the use of the Drop trait.
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum KeyMode {
     Read,
     ReadWrite,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,12 +68,10 @@ pub fn base_info_func(
     extended_info_func: Option<fn(&InfoContext, bool)>,
 ) {
     // If needed, add rust trace into the crash report (before module info)
-    if for_crash_report {
-        if ctx.add_info_section(Some("trace")) == Status::Ok {
-            let current_backtrace = Backtrace::new();
-            let trace = format!("{:?}", current_backtrace);
-            ctx.add_info_field_str("trace", &trace);
-        }
+    if for_crash_report && ctx.add_info_section(Some("trace")) == Status::Ok {
+        let current_backtrace = Backtrace::new();
+        let trace = format!("{:?}", current_backtrace);
+        ctx.add_info_field_str("trace", &trace);
     }
 
     if let Some(func) = extended_info_func {

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -6,6 +6,7 @@ extern crate enum_primitive_derive;
 extern crate libc;
 extern crate num_traits;
 
+use std::cmp::Ordering;
 use std::ffi::{CStr, CString};
 use std::os::raw::{c_char, c_double, c_int, c_long, c_longlong};
 use std::ptr;
@@ -549,6 +550,11 @@ pub fn save_float(rdb: *mut RedisModuleIO, val: f32) {
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
 pub fn save_unsigned(rdb: *mut RedisModuleIO, val: u64) {
     unsafe { RedisModule_SaveUnsigned.unwrap()(rdb, val) };
+}
+
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
+pub fn string_compare(a: *const RedisModuleString, b: *const RedisModuleString) -> Ordering {
+    unsafe { RedisModule_StringCompare.unwrap()(a, b).cmp(&0) }
 }
 
 #[allow(clippy::not_unsafe_ptr_arg_deref)]

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -36,7 +36,7 @@ bitflags! {
     }
 }
 
-#[derive(Primitive, Debug, PartialEq)]
+#[derive(Primitive, Debug, PartialEq, Eq)]
 pub enum KeyType {
     Empty = REDISMODULE_KEYTYPE_EMPTY,
     String = REDISMODULE_KEYTYPE_STRING,
@@ -54,13 +54,13 @@ impl From<c_int> for KeyType {
     }
 }
 
-#[derive(Primitive, Debug, PartialEq)]
+#[derive(Primitive, Debug, PartialEq, Eq)]
 pub enum Where {
     ListHead = REDISMODULE_LIST_HEAD,
     ListTail = REDISMODULE_LIST_TAIL,
 }
 
-#[derive(Primitive, Debug, PartialEq)]
+#[derive(Primitive, Debug, PartialEq, Eq)]
 pub enum ReplyType {
     Unknown = REDISMODULE_REPLY_UNKNOWN,
     String = REDISMODULE_REPLY_STRING,
@@ -76,13 +76,13 @@ impl From<c_int> for ReplyType {
     }
 }
 
-#[derive(Primitive, Debug, PartialEq)]
+#[derive(Primitive, Debug, PartialEq, Eq)]
 pub enum Aux {
     Before = REDISMODULE_AUX_BEFORE_RDB,
     After = REDISMODULE_AUX_AFTER_RDB,
 }
 
-#[derive(Primitive, Debug, PartialEq)]
+#[derive(Primitive, Debug, PartialEq, Eq)]
 pub enum Status {
     Ok = REDISMODULE_OK,
     Err = REDISMODULE_ERR,
@@ -225,13 +225,7 @@ pub fn call_reply_string(reply: *mut RedisModuleCallReply) -> String {
         let mut len: size_t = 0;
         let reply_string: *mut u8 =
             RedisModule_CallReplyStringPtr.unwrap()(reply, &mut len) as *mut u8;
-        String::from_utf8(
-            slice::from_raw_parts(reply_string, len)
-                .iter()
-                .copied()
-                .collect(),
-        )
-        .unwrap()
+        String::from_utf8(slice::from_raw_parts(reply_string, len).to_vec()).unwrap()
     }
 }
 
@@ -645,7 +639,7 @@ pub fn get_keyspace_events() -> NotifyEvent {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct Version {
     pub major: i32,
     pub minor: i32,

--- a/src/redismodule.rs
+++ b/src/redismodule.rs
@@ -88,7 +88,7 @@ pub fn decode_args(
 
 ///////////////////////////////////////////////////
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub struct RedisString {
     ctx: *mut raw::RedisModuleCtx,
     pub inner: *mut raw::RedisModuleString,
@@ -201,6 +201,32 @@ impl Drop for RedisString {
         unsafe {
             raw::RedisModule_FreeString.unwrap()(self.ctx, self.inner);
         }
+    }
+}
+
+impl PartialEq for RedisString {
+    fn eq(&self, other: &Self) -> bool {
+        self.cmp(other).is_eq()
+    }
+}
+
+impl Eq for RedisString {}
+
+impl PartialOrd for RedisString {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for RedisString {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        raw::string_compare(self.inner, other.inner)
+    }
+}
+
+impl core::hash::Hash for RedisString {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.as_slice().hash(state);
     }
 }
 


### PR DESCRIPTION
These are useful if you want to save some allocations and manipulate with `RedisString`s directly.