### PR TITLE
Remove misleading comments "assume NULL terminated"

### DIFF
--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -296,26 +296,15 @@ impl InfoContext {
         Self { ctx }
     }
 
-    pub fn add_info_section(
-        &self,
-        name: Option<&str>, // assume NULL terminated
-    ) -> Status {
+    pub fn add_info_section(&self, name: Option<&str>) -> Status {
         add_info_section(self.ctx, name)
     }
 
-    pub fn add_info_field_str(
-        &self,
-        name: &str, // assume NULL terminated
-        content: &str,
-    ) -> Status {
+    pub fn add_info_field_str(&self, name: &str, content: &str) -> Status {
         add_info_field_str(self.ctx, name, content)
     }
 
-    pub fn add_info_field_long_long(
-        &self,
-        name: &str, // assume NULL terminated
-        value: c_longlong,
-    ) -> Status {
+    pub fn add_info_field_long_long(&self, name: &str, value: c_longlong) -> Status {
         add_info_field_long_long(self.ctx, name, value)
     }
 }

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -578,10 +578,7 @@ pub fn register_info_function(ctx: *mut RedisModuleCtx, callback: RedisModuleInf
 }
 
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
-pub fn add_info_section(
-    ctx: *mut RedisModuleInfoCtx,
-    name: Option<&str>, // assume NULL terminated
-) -> Status {
+pub fn add_info_section(ctx: *mut RedisModuleInfoCtx, name: Option<&str>) -> Status {
     name.map(|n| CString::new(n).unwrap()).map_or_else(
         || unsafe { RedisModule_InfoAddSection.unwrap()(ctx, ptr::null_mut()).into() },
         |n| unsafe { RedisModule_InfoAddSection.unwrap()(ctx, n.as_ptr() as *mut c_char).into() },
@@ -589,11 +586,7 @@ pub fn add_info_section(
 }
 
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
-pub fn add_info_field_str(
-    ctx: *mut RedisModuleInfoCtx,
-    name: &str, // assume NULL terminated
-    content: &str,
-) -> Status {
+pub fn add_info_field_str(ctx: *mut RedisModuleInfoCtx, name: &str, content: &str) -> Status {
     let name = CString::new(name).unwrap();
     let content = RedisString::create(ptr::null_mut(), content);
     unsafe {
@@ -605,7 +598,7 @@ pub fn add_info_field_str(
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
 pub fn add_info_field_long_long(
     ctx: *mut RedisModuleInfoCtx,
-    name: &str, // assume NULL terminated
+    name: &str,
     value: c_longlong,
 ) -> Status {
     let name = CString::new(name).unwrap();


### PR DESCRIPTION
No need to "assume NULL terminated"
since a `CString` is used and will add the required terminating `NULL`.
