### PR TITLE
MOD-2484: avoid crash on null in err reply string

### DIFF
--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -2,7 +2,6 @@
 extern crate redis_module;
 
 use redis_module::InfoContext;
-use redis_module::RedisValue;
 use redis_module::Status;
 
 use redis_module::{Context, RedisError, RedisResult, RedisString};
@@ -33,7 +32,7 @@ fn hello_err(ctx: &Context, args: Vec<RedisString>) -> RedisResult {
     let msg = args.get(1).unwrap();
 
     ctx.reply_error_string(msg.try_as_str().unwrap());
-    Ok(RedisValue::SimpleStringStatic("OK"))
+    Ok(().into())
 }
 
 fn add_info(ctx: &InfoContext, _for_crash_report: bool) {

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -2,6 +2,7 @@
 extern crate redis_module;
 
 use redis_module::InfoContext;
+use redis_module::RedisValue;
 use redis_module::Status;
 
 use redis_module::{Context, RedisError, RedisResult, RedisString};
@@ -24,6 +25,17 @@ fn hello_mul(_: &Context, args: Vec<RedisString>) -> RedisResult {
     return Ok(response.into());
 }
 
+fn hello_err(ctx: &Context, args: Vec<RedisString>) -> RedisResult {
+    if args.len() < 1 {
+        return Err(RedisError::WrongArity);
+    }
+
+    let msg = args.get(1).unwrap();
+
+    ctx.reply_error_string(msg.try_as_str().unwrap());
+    Ok(RedisValue::SimpleStringStatic("OK"))
+}
+
 fn add_info(ctx: &InfoContext, _for_crash_report: bool) {
     if ctx.add_info_section(Some("hello")) == Status::Ok {
         ctx.add_info_field_str("field", "hello_value");
@@ -39,5 +51,6 @@ redis_module! {
     info: add_info,
     commands: [
         ["hello.mul", hello_mul, "", 0, 0, 0],
+        ["hello.err", hello_err, "", 0, 0, 0],
     ],
 }

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -141,7 +141,7 @@ impl Context {
         CString::new(
             s.chars()
                 .map(|c| match c {
-                    '\r' | '\n' => b' ',
+                    '\r' | '\n' | '\0' => b' ',
                     _ => c as u8,
                 })
                 .collect::<Vec<_>>(),

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -64,3 +64,23 @@ fn test_hello_info() -> Result<()> {
 
     Ok(())
 }
+
+#[allow(unused_must_use)]
+#[test]
+fn test_hello_err() -> Result<()> {
+    let _guards = vec![start_redis_server_with_module("hello", 6482)
+        .with_context(|| "failed to start redis server")?];
+    let mut con =
+        get_redis_connection(6482).with_context(|| "failed to connect to redis server")?;
+
+    // Make sure embedded nulls do not cause a crash
+    redis::cmd("hello.err")
+        .arg(&["\x00\x00"])
+        .query::<String>(&mut con);
+
+    redis::cmd("hello.err")
+        .arg(&["no crash\x00"])
+        .query::<String>(&mut con);
+
+    Ok(())
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -76,11 +76,11 @@ fn test_hello_err() -> Result<()> {
     // Make sure embedded nulls do not cause a crash
     redis::cmd("hello.err")
         .arg(&["\x00\x00"])
-        .query::<String>(&mut con);
+        .query::<()>(&mut con);
 
     redis::cmd("hello.err")
         .arg(&["no crash\x00"])
-        .query::<String>(&mut con);
+        .query::<()>(&mut con);
 
     Ok(())
 }


### PR DESCRIPTION
JSON.GET on an existing JSON key with a path containing one or more null characters causes a crash, e.g.,
```
json.set test $ '{}'
OK
json.get test "\x00"
```
