### PR TITLE
Publicizing RedisKey member

### DIFF
--- a/examples/data_type.rs
+++ b/examples/data_type.rs
@@ -37,7 +37,7 @@ static MY_REDIS_TYPE: RedisType = RedisType::new(
 );
 
 unsafe extern "C" fn free(value: *mut c_void) {
-    Box::from_raw(value.cast::<MyType>());
+    drop(Box::from_raw(value.cast::<MyType>()));
 }
 
 fn alloc_set(ctx: &Context, args: Vec<RedisString>) -> RedisResult {

--- a/src/key.rs
+++ b/src/key.rs
@@ -33,7 +33,7 @@ pub enum KeyMode {
 #[derive(Debug)]
 pub struct RedisKey {
     ctx: *mut raw::RedisModuleCtx,
-    key_inner: *mut raw::RedisModuleKey,
+    pub key_inner: *mut raw::RedisModuleKey,
 }
 
 impl RedisKey {


### PR DESCRIPTION
Maybe `RedisKey::key_inner` shouldn't be public in the general case, but it is required for a module that wants to call C fns expecting `*RedisModuleKey` given Rust structs.