### PR TITLE
Added API to register to server events.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,10 @@ name = "load_unload"
 crate-type = ["cdylib"]
 
 [[example]]
+name = "server_events"
+crate-type = ["cdylib"]
+
+[[example]]
 name = "events"
 crate-type = ["cdylib"]
 required-features = ["experimental-api"]
@@ -74,10 +78,12 @@ regex = "1"
 strum_macros = "0.24"
 #failure = "0.1"
 backtrace = "0.3"
+linkme = "0.3"
 
 [dev-dependencies]
 anyhow = "1.0.38"
 redis = "0.22.1"
+redis_module_derive = { path = "./redismodule-rs-derive"}
 
 [build-dependencies]
 bindgen = "0.63"

--- a/examples/server_events.rs
+++ b/examples/server_events.rs
@@ -1,0 +1,30 @@
+#[macro_use]
+extern crate redis_module;
+
+use redis_module::{server_events::FlushSubevent, Context, RedisResult, RedisString, RedisValue};
+use redis_module_derive::flush_event_handler;
+
+pub static mut NUM_FLUSHES: usize = 0;
+
+#[flush_event_handler]
+fn flushed_event_handler(_ctx: &Context, flush_event: FlushSubevent) {
+    match flush_event {
+        FlushSubevent::Started => unsafe { NUM_FLUSHES += 1 },
+        _ => (),
+    }
+}
+
+fn num_flushed(_ctx: &Context, _args: Vec<RedisString>) -> RedisResult {
+    Ok(RedisValue::Integer(unsafe { NUM_FLUSHES } as i64))
+}
+
+//////////////////////////////////////////////////////
+
+redis_module! {
+    name: "server_events",
+    version: 1,
+    data_types: [],
+    commands: [
+        ["num_flushed", num_flushed, "", 0, 0, 0],
+    ],
+}

--- a/redismodule-rs-derive/Cargo.toml
+++ b/redismodule-rs-derive/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "redis_module_derive"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+syn = { version="1.0", features = ["full"]}
+quote = "1.0"
+
+[lib]
+name = "redis_module_derive"
+path = "src/lib.rs"
+proc-macro = true

--- a/redismodule-rs-derive/src/lib.rs
+++ b/redismodule-rs-derive/src/lib.rs
@@ -1,0 +1,57 @@
+extern crate proc_macro;
+use proc_macro::TokenStream;
+use quote::quote;
+use syn;
+use syn::ItemFn;
+
+#[proc_macro_attribute]
+pub fn role_changed_event_handler(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    let ast: ItemFn = match syn::parse(item) {
+        Ok(res) => res,
+        Err(e) => return e.to_compile_error().into(),
+    };
+    let gen = quote! {
+        #[linkme::distributed_slice(redis_module::server_events::ROLE_CHANGED_SERVER_EVENTS_LIST)]
+        #ast
+    };
+    gen.into()
+}
+
+#[proc_macro_attribute]
+pub fn loading_event_handler(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    let ast: ItemFn = match syn::parse(item) {
+        Ok(res) => res,
+        Err(e) => return e.to_compile_error().into(),
+    };
+    let gen = quote! {
+        #[linkme::distributed_slice(redis_module::server_events::LOADING_SERVER_EVENTS_LIST)]
+        #ast
+    };
+    gen.into()
+}
+
+#[proc_macro_attribute]
+pub fn flush_event_handler(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    let ast: ItemFn = match syn::parse(item) {
+        Ok(res) => res,
+        Err(e) => return e.to_compile_error().into(),
+    };
+    let gen = quote! {
+        #[linkme::distributed_slice(redis_module::server_events::FLUSH_SERVER_EVENTS_LIST)]
+        #ast
+    };
+    gen.into()
+}
+
+#[proc_macro_attribute]
+pub fn module_changed_event_handler(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    let ast: ItemFn = match syn::parse(item) {
+        Ok(res) => res,
+        Err(e) => return e.to_compile_error().into(),
+    };
+    let gen = quote! {
+        #[linkme::distributed_slice(redis_module::server_events::MODULE_CHANGED_SERVER_EVENTS_LIST)]
+        #ast
+    };
+    gen.into()
+}

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -22,6 +22,8 @@ pub mod blocked;
 
 pub mod info;
 
+pub mod server_events;
+
 /// `Context` is a structure that's designed to give us a high-level interface to
 /// the Redis module API by abstracting away the raw C FFI calls.
 pub struct Context {

--- a/src/context/server_events.rs
+++ b/src/context/server_events.rs
@@ -1,0 +1,192 @@
+use crate::raw;
+use crate::{context::Context, RedisError};
+use linkme::distributed_slice;
+
+#[derive(Clone)]
+pub enum ServerRole {
+    Primary,
+    Replica,
+}
+
+#[derive(Clone)]
+pub enum LoadingSubevent {
+    RdbStarted,
+    AofStarted,
+    ReplStarted,
+    Ended,
+    Failed,
+}
+
+#[derive(Clone)]
+pub enum FlushSubevent {
+    Started,
+    Ended,
+}
+
+#[derive(Clone)]
+pub enum ModuleChangeSubevent {
+    Loaded,
+    Unloaded,
+}
+
+pub enum ServerEventHandler {
+    RuleChanged(fn(&Context, ServerRole)),
+    Loading(fn(&Context, LoadingSubevent)),
+    Flush(fn(&Context, FlushSubevent)),
+    ModuleChange(fn(&Context, ModuleChangeSubevent)),
+}
+
+#[distributed_slice()]
+pub static ROLE_CHANGED_SERVER_EVENTS_LIST: [fn(&Context, ServerRole)] = [..];
+
+#[distributed_slice()]
+pub static LOADING_SERVER_EVENTS_LIST: [fn(&Context, LoadingSubevent)] = [..];
+
+#[distributed_slice()]
+pub static FLUSH_SERVER_EVENTS_LIST: [fn(&Context, FlushSubevent)] = [..];
+
+#[distributed_slice()]
+pub static MODULE_CHANGED_SERVER_EVENTS_LIST: [fn(&Context, ModuleChangeSubevent)] = [..];
+
+extern "C" fn role_changed_callback(
+    ctx: *mut raw::RedisModuleCtx,
+    _eid: raw::RedisModuleEvent,
+    subevent: u64,
+    _data: *mut ::std::os::raw::c_void,
+) {
+    let new_role = if subevent == raw::REDISMODULE_EVENT_REPLROLECHANGED_NOW_MASTER {
+        ServerRole::Primary
+    } else {
+        ServerRole::Replica
+    };
+    let ctx = Context::new(ctx);
+    for callback in ROLE_CHANGED_SERVER_EVENTS_LIST.iter() {
+        callback(&ctx, new_role.clone());
+    }
+}
+
+extern "C" fn loading_event_callback(
+    ctx: *mut raw::RedisModuleCtx,
+    _eid: raw::RedisModuleEvent,
+    subevent: u64,
+    _data: *mut ::std::os::raw::c_void,
+) {
+    let loading_sub_event = match subevent {
+        raw::REDISMODULE_SUBEVENT_LOADING_RDB_START => LoadingSubevent::RdbStarted,
+        raw::REDISMODULE_SUBEVENT_LOADING_REPL_START => LoadingSubevent::ReplStarted,
+        raw::REDISMODULE_SUBEVENT_LOADING_ENDED => LoadingSubevent::Ended,
+        _ => LoadingSubevent::Failed,
+    };
+    let ctx = Context::new(ctx);
+    for callback in LOADING_SERVER_EVENTS_LIST.iter() {
+        callback(&ctx, loading_sub_event.clone());
+    }
+}
+
+extern "C" fn flush_event_callback(
+    ctx: *mut raw::RedisModuleCtx,
+    _eid: raw::RedisModuleEvent,
+    subevent: u64,
+    _data: *mut ::std::os::raw::c_void,
+) {
+    let flush_sub_event = if subevent == raw::REDISMODULE_SUBEVENT_FLUSHDB_START {
+        FlushSubevent::Started
+    } else {
+        FlushSubevent::Ended
+    };
+    let ctx = Context::new(ctx);
+    for callback in FLUSH_SERVER_EVENTS_LIST.iter() {
+        callback(&ctx, flush_sub_event.clone());
+    }
+}
+
+extern "C" fn module_change_event_callback(
+    ctx: *mut raw::RedisModuleCtx,
+    _eid: raw::RedisModuleEvent,
+    subevent: u64,
+    _data: *mut ::std::os::raw::c_void,
+) {
+    let module_changed_sub_event = if subevent == raw::REDISMODULE_SUBEVENT_MODULE_LOADED {
+        ModuleChangeSubevent::Loaded
+    } else {
+        ModuleChangeSubevent::Unloaded
+    };
+    let ctx = Context::new(ctx);
+    for callback in MODULE_CHANGED_SERVER_EVENTS_LIST.iter() {
+        callback(&ctx, module_changed_sub_event.clone());
+    }
+}
+
+pub fn register_server_events(ctx: &Context) -> Result<(), RedisError> {
+    if !ROLE_CHANGED_SERVER_EVENTS_LIST.is_empty() {
+        let res = unsafe {
+            raw::RedisModule_SubscribeToServerEvent.unwrap()(
+                ctx.ctx,
+                raw::RedisModuleEvent {
+                    id: raw::REDISMODULE_EVENT_REPLICATION_ROLE_CHANGED,
+                    dataver: 1,
+                },
+                Some(role_changed_callback),
+            )
+        };
+        if res != raw::REDISMODULE_OK as i32 {
+            return Err(RedisError::Str(
+                "Failed subscribing to role changed server event",
+            ));
+        }
+    }
+
+    if !LOADING_SERVER_EVENTS_LIST.is_empty() {
+        let res = unsafe {
+            raw::RedisModule_SubscribeToServerEvent.unwrap()(
+                ctx.ctx,
+                raw::RedisModuleEvent {
+                    id: raw::REDISMODULE_EVENT_LOADING,
+                    dataver: 1,
+                },
+                Some(loading_event_callback),
+            )
+        };
+        if res != raw::REDISMODULE_OK as i32 {
+            return Err(RedisError::Str(
+                "Failed subscribing to loading server event",
+            ));
+        }
+    }
+
+    if !FLUSH_SERVER_EVENTS_LIST.is_empty() {
+        let res = unsafe {
+            raw::RedisModule_SubscribeToServerEvent.unwrap()(
+                ctx.ctx,
+                raw::RedisModuleEvent {
+                    id: raw::REDISMODULE_EVENT_FLUSHDB,
+                    dataver: 1,
+                },
+                Some(flush_event_callback),
+            )
+        };
+        if res != raw::REDISMODULE_OK as i32 {
+            return Err(RedisError::Str("Failed subscribing to flush server event"));
+        }
+    }
+
+    if !MODULE_CHANGED_SERVER_EVENTS_LIST.is_empty() {
+        let res = unsafe {
+            raw::RedisModule_SubscribeToServerEvent.unwrap()(
+                ctx.ctx,
+                raw::RedisModuleEvent {
+                    id: raw::REDISMODULE_EVENT_MODULE_CHANGE,
+                    dataver: 1,
+                },
+                Some(module_change_event_callback),
+            )
+        };
+        if res != raw::REDISMODULE_OK as i32 {
+            return Err(RedisError::Str(
+                "Failed subscribing to module changed server event",
+            ));
+        }
+    }
+
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,7 @@ pub use crate::context::thread_safe::{DetachedFromClient, ThreadSafeContext};
 #[cfg(feature = "experimental-api")]
 pub use crate::raw::NotifyEvent;
 
+pub use crate::context::server_events;
 pub use crate::context::Context;
 pub use crate::raw::*;
 pub use crate::redismodule::*;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -132,6 +132,7 @@ macro_rules! redis_module {
 
             use $crate::raw;
             use $crate::RedisString;
+            use $crate::server_events::register_server_events;
 
             // We use a statically sized buffer to avoid allocating.
             // This is needed since we use a custom allocator that relies on the Redis allocator,
@@ -180,6 +181,11 @@ macro_rules! redis_module {
             )?
 
             raw::register_info_function(ctx, Some(__info_func));
+
+            if let Err(e) = register_server_events(&context) {
+                context.log_warning(&format!("{}", e));
+                return raw::Status::Err as c_int;
+            }
 
             raw::Status::Ok as c_int
         }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -168,3 +168,30 @@ fn test_string() -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn test_server_event() -> Result<()> {
+    let port: u16 = 6486;
+    let _guards = vec![start_redis_server_with_module("server_events", port)
+        .with_context(|| "failed to start redis server")?];
+    let mut con =
+        get_redis_connection(port).with_context(|| "failed to connect to redis server")?;
+
+    redis::cmd("flushall")
+        .query(&mut con)
+        .with_context(|| "failed to run string.set")?;
+
+    let res: i64 = redis::cmd("num_flushed").query(&mut con)?;
+
+    assert_eq!(res, 1);
+
+    redis::cmd("flushall")
+        .query(&mut con)
+        .with_context(|| "failed to run string.set")?;
+
+    let res: i64 = redis::cmd("num_flushed").query(&mut con)?;
+
+    assert_eq!(res, 2);
+
+    Ok(())
+}


### PR DESCRIPTION
The PR also introduce a new crate, redismodule-rs-derive, which is use to implement derive and proc macro functionality. Server events are registered using a `proc_macro_attribute` that add the server event handler to the relevant list server events handler list. This binding is done using: https://github.com/dtolnay/linkme