### PR TITLE
add RESP3 new APIs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,10 @@ crate-type = ["cdylib"]
 name = "stream"
 crate-type = ["cdylib"]
 
+[[example]]
+name = "response"
+crate-type = ["cdylib"]
+
 [dependencies]
 bitflags = "1.2"
 libc = "0.2"

--- a/examples/call.rs
+++ b/examples/call.rs
@@ -1,9 +1,8 @@
 #[macro_use]
 extern crate redis_module;
 
-use redis_module::raw::*;
 use redis_module::{
-    CallOptionsBuilder, CallReply, Context, RedisError, RedisResult, RedisString, RootCallReply,
+    CallOptionsBuilder, CallReply, Context, RedisError, RedisResult, RedisString, CallOptionResp,
 };
 
 fn call_test(ctx: &Context, _: Vec<RedisString>) -> RedisResult {
@@ -66,15 +65,51 @@ fn call_test(ctx: &Context, _: Vec<RedisString>) -> RedisResult {
     }
 
     let call_options = CallOptionsBuilder::new().script_mode().errors_as_replies();
-    let res: RootCallReply = ctx.call_ext::<&[&str; 0], _>("SHUTDOWN", &call_options.build(), &[]);
-    if res.get_type() != ReplyType::Error {
+    let res: CallReply = ctx.call_ext::<&[&str; 0], _>("SHUTDOWN", &call_options.build(), &[]);
+    if let CallReply::Error(err) = res {
+        let error_msg = err.to_string().unwrap();
+        if !error_msg.contains("not allow") {
+            return Err(RedisError::String(format!(
+                "Failed to verify error messages, expected error message to contain 'not allow', error message: '{error_msg}'",
+            )));
+        }
+    } else {
         return Err(RedisError::Str("Failed to set script mode on call_ext"));
     }
-    let error_msg = res.get_string().unwrap();
-    if !error_msg.contains("not allow") {
+
+    // test resp3 on call_ext
+    let call_options = CallOptionsBuilder::new().script_mode().resp_3(CallOptionResp::Resp3).errors_as_replies().build();
+    let res: CallReply = ctx.call_ext("HSET", &call_options, &["x", "foo", "bar"]);
+    if let CallReply::Error(err) = res {
         return Err(RedisError::String(format!(
-            "Failed to verify error messages, expected error message to contain 'not allow', error message: '{error_msg}'",
+            "Failed setting value on hset, error message: '{}'", err.to_string().unwrap(),
         )));
+    }
+    let res: CallReply = ctx.call_ext("HGETALL", &call_options, &["x"]);
+    if let CallReply::Error(err) = res {
+        return Err(RedisError::String(format!(
+            "Failed performing hgetall, error message: '{}'", err.to_string().unwrap(),
+        )));
+    }
+    if let CallReply::Map(map) = res {
+        let res = map.iter().fold(Vec::new(), |mut vec, (key, val)|{
+            if let CallReply::String(key) = key {
+                vec.push(key.to_string().unwrap());
+            }
+            if let CallReply::String(val) = val {
+                vec.push(val.to_string().unwrap());
+            }
+            vec
+        });
+        if res != vec!["foo".to_string(), "bar".to_string()] {
+            return Err(RedisError::String(
+                "Reply of hgetall does not match expected value".into()
+            ));
+        }
+    }else {
+        return Err(RedisError::String(
+            "Did not get a set type on hgetall".into()
+        ));
     }
 
     Ok("pass".into())

--- a/examples/call.rs
+++ b/examples/call.rs
@@ -2,7 +2,7 @@
 extern crate redis_module;
 
 use redis_module::{
-    CallOptionsBuilder, CallReply, Context, RedisError, RedisResult, RedisString, CallOptionResp,
+    CallOptionResp, CallOptionsBuilder, CallReply, Context, RedisError, RedisResult, RedisString,
 };
 
 fn call_test(ctx: &Context, _: Vec<RedisString>) -> RedisResult {
@@ -78,21 +78,27 @@ fn call_test(ctx: &Context, _: Vec<RedisString>) -> RedisResult {
     }
 
     // test resp3 on call_ext
-    let call_options = CallOptionsBuilder::new().script_mode().resp_3(CallOptionResp::Resp3).errors_as_replies().build();
+    let call_options = CallOptionsBuilder::new()
+        .script_mode()
+        .resp_3(CallOptionResp::Resp3)
+        .errors_as_replies()
+        .build();
     let res: CallReply = ctx.call_ext("HSET", &call_options, &["x", "foo", "bar"]);
     if let CallReply::Error(err) = res {
         return Err(RedisError::String(format!(
-            "Failed setting value on hset, error message: '{}'", err.to_string().unwrap(),
+            "Failed setting value on hset, error message: '{}'",
+            err.to_string().unwrap(),
         )));
     }
     let res: CallReply = ctx.call_ext("HGETALL", &call_options, &["x"]);
     if let CallReply::Error(err) = res {
         return Err(RedisError::String(format!(
-            "Failed performing hgetall, error message: '{}'", err.to_string().unwrap(),
+            "Failed performing hgetall, error message: '{}'",
+            err.to_string().unwrap(),
         )));
     }
     if let CallReply::Map(map) = res {
-        let res = map.iter().fold(Vec::new(), |mut vec, (key, val)|{
+        let res = map.iter().fold(Vec::new(), |mut vec, (key, val)| {
             if let CallReply::String(key) = key {
                 vec.push(key.to_string().unwrap());
             }
@@ -103,12 +109,12 @@ fn call_test(ctx: &Context, _: Vec<RedisString>) -> RedisResult {
         });
         if res != vec!["foo".to_string(), "bar".to_string()] {
             return Err(RedisError::String(
-                "Reply of hgetall does not match expected value".into()
+                "Reply of hgetall does not match expected value".into(),
             ));
         }
-    }else {
+    } else {
         return Err(RedisError::String(
-            "Did not get a set type on hgetall".into()
+            "Did not get a set type on hgetall".into(),
         ));
     }
 

--- a/examples/response.rs
+++ b/examples/response.rs
@@ -1,0 +1,72 @@
+#[macro_use]
+extern crate redis_module;
+
+use redis_module::{Context, NextArg, RedisError, RedisResult, RedisString, RedisValue};
+use std::collections::{HashMap, HashSet};
+
+fn map_mget(ctx: &Context, args: Vec<RedisString>) -> RedisResult {
+    if args.len() < 2 {
+        return Err(RedisError::WrongArity);
+    }
+
+    let mut args = args.into_iter().skip(1);
+    let key_name = args.next_arg()?;
+
+    let fields: Vec<RedisString> = args.collect();
+
+    let key = ctx.open_key(&key_name);
+    let values = key.hash_get_multi(&fields)?;
+    let res = match values {
+        None => RedisValue::Null,
+        Some(values) => {
+            let mut map: HashMap<RedisValue, RedisValue> = HashMap::with_capacity(fields.len());
+            for (field, value) in values.into_iter() {
+                map.insert(
+                    RedisValue::BulkRedisString(field),
+                    RedisValue::BulkRedisString(value),
+                );
+            }
+            RedisValue::Map(map)
+        }
+    };
+
+    Ok(res)
+}
+
+fn map_unique(ctx: &Context, args: Vec<RedisString>) -> RedisResult {
+    if args.len() < 2 {
+        return Err(RedisError::WrongArity);
+    }
+
+    let mut args = args.into_iter().skip(1);
+    let key_name = args.next_arg()?;
+
+    let fields: Vec<RedisString> = args.collect();
+
+    let key = ctx.open_key(&key_name);
+    let values = key.hash_get_multi(&fields)?;
+    let res = match values {
+        None => RedisValue::Null,
+        Some(values) => {
+            let mut set: HashSet<RedisValue> = HashSet::new();
+            for (_, value) in values.into_iter() {
+                set.insert(RedisValue::BulkRedisString(value));
+            }
+            RedisValue::Set(set)
+        }
+    };
+
+    Ok(res)
+}
+
+//////////////////////////////////////////////////////
+
+redis_module! {
+    name: "response",
+    version: 1,
+    data_types: [],
+    commands: [
+        ["map.mget", map_mget, "readonly", 1, 1, 1],
+        ["map.unique", map_unique, "readonly", 1, 1, 1],
+    ],
+}

--- a/examples/response.rs
+++ b/examples/response.rs
@@ -1,7 +1,9 @@
 #[macro_use]
 extern crate redis_module;
 
-use redis_module::{Context, NextArg, RedisError, RedisResult, RedisString, RedisValue};
+use redis_module::{
+    redisvalue::RedisValueKey, Context, NextArg, RedisError, RedisResult, RedisString, RedisValue,
+};
 use std::collections::{HashMap, HashSet};
 
 fn map_mget(ctx: &Context, args: Vec<RedisString>) -> RedisResult {
@@ -19,10 +21,10 @@ fn map_mget(ctx: &Context, args: Vec<RedisString>) -> RedisResult {
     let res = match values {
         None => RedisValue::Null,
         Some(values) => {
-            let mut map: HashMap<RedisValue, RedisValue> = HashMap::with_capacity(fields.len());
+            let mut map: HashMap<RedisValueKey, RedisValue> = HashMap::with_capacity(fields.len());
             for (field, value) in values.into_iter() {
                 map.insert(
-                    RedisValue::BulkRedisString(field),
+                    RedisValueKey::BulkRedisString(field),
                     RedisValue::BulkRedisString(value),
                 );
             }
@@ -48,9 +50,9 @@ fn map_unique(ctx: &Context, args: Vec<RedisString>) -> RedisResult {
     let res = match values {
         None => RedisValue::Null,
         Some(values) => {
-            let mut set: HashSet<RedisValue> = HashSet::new();
+            let mut set: HashSet<RedisValueKey> = HashSet::new();
             for (_, value) in values.into_iter() {
-                set.insert(RedisValue::BulkRedisString(value));
+                set.insert(RedisValueKey::BulkRedisString(value));
             }
             RedisValue::Set(set)
         }

--- a/examples/string.rs
+++ b/examples/string.rs
@@ -40,7 +40,7 @@ redis_module! {
     version: 1,
     data_types: [],
     commands: [
-        ["string.set", string_set, "", 1, 1, 1],
-        ["string.get", string_get, "", 1, 1, 1],
+        ["string.set", string_set, "write fast deny-oom", 1, 1, 1],
+        ["string.get", string_get, "readonly", 1, 1, 1],
     ],
 }

--- a/src/context/call_reply.rs
+++ b/src/context/call_reply.rs
@@ -2,7 +2,7 @@ use core::slice;
 use std::{
     ffi::c_char,
     fmt,
-    fmt::{Debug, Formatter},
+    fmt::{Debug, Display, Formatter},
     marker::PhantomData,
     ptr::NonNull,
 };
@@ -39,7 +39,25 @@ impl<'root> Drop for StringCallReply<'root> {
 
 impl<'root> Debug for StringCallReply<'root> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "{:?}", self.as_bytes())
+        let mut debug_struct = f.debug_struct("StringCallReply");
+        let debug_struct = debug_struct.field("reply", &self.reply);
+        match self.to_string() {
+            Some(s) => debug_struct.field("value", &s),
+            None => debug_struct.field("value", &self.as_bytes()),
+        }
+        .finish()
+    }
+}
+
+impl<'root> Display for StringCallReply<'root> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(
+            self.to_string()
+                .as_ref()
+                .map(|v| v.as_str())
+                .unwrap_or("None"),
+            f,
+        )
     }
 }
 
@@ -73,7 +91,25 @@ impl<'root> Drop for ErrorCallReply<'root> {
 
 impl<'root> Debug for ErrorCallReply<'root> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "{:?}", self.to_string())
+        let mut debug_struct = f.debug_struct("ErrorCallReply");
+        let debug_struct = debug_struct.field("reply", &self.reply);
+        match self.to_string() {
+            Some(s) => debug_struct.field("value", &s),
+            None => debug_struct.field("value", &self.as_bytes()),
+        }
+        .finish()
+    }
+}
+
+impl<'root> Display for ErrorCallReply<'root> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(
+            self.to_string()
+                .as_ref()
+                .map(|v| v.as_str())
+                .unwrap_or("None"),
+            f,
+        )
     }
 }
 
@@ -97,7 +133,16 @@ impl<'root> Drop for I64CallReply<'root> {
 
 impl<'root> Debug for I64CallReply<'root> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "{:?}", self.to_i64())
+        f.debug_struct("I64CallReply")
+            .field("reply", &self.reply)
+            .field("value", &self.to_i64())
+            .finish()
+    }
+}
+
+impl<'root> Display for I64CallReply<'root> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.to_i64(), f)
     }
 }
 
@@ -153,8 +198,27 @@ impl<'root, 'curr> Iterator for ArrayCallReplyIterator<'root, 'curr> {
 
 impl<'root> Debug for ArrayCallReply<'root> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        let children: Vec<CallResult> = self.iter().collect();
-        write!(f, "{:?}", children)
+        f.debug_struct("ArrayCallReply")
+            .field("reply", &self.reply)
+            .field("elements", &self.iter().collect::<Vec<CallResult>>())
+            .finish()
+    }
+}
+
+impl<'root> Display for ArrayCallReply<'root> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.write_str("[")?;
+
+        self.iter()
+            .enumerate()
+            .try_for_each(|(index, v)| -> fmt::Result {
+                if index > 1 {
+                    f.write_str(", ")?;
+                }
+                fmt_call_result(v, f)
+            })?;
+
+        f.write_str("]")
     }
 }
 
@@ -171,7 +235,15 @@ impl<'root> Drop for NullCallReply<'root> {
 
 impl<'root> Debug for NullCallReply<'root> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "Null")
+        f.debug_struct("NullCallReply")
+            .field("reply", &self.reply)
+            .finish()
+    }
+}
+
+impl<'root> Display for NullCallReply<'root> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.write_str("Null")
     }
 }
 
@@ -231,8 +303,33 @@ impl<'root> Drop for MapCallReply<'root> {
 
 impl<'root> Debug for MapCallReply<'root> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        let elements: Vec<(CallResult, CallResult)> = self.iter().collect();
-        write!(f, "{:?}", elements)
+        f.debug_struct("MapCallReply")
+            .field("reply", &self.reply)
+            .field(
+                "elements",
+                &self.iter().collect::<Vec<(CallResult, CallResult)>>(),
+            )
+            .finish()
+    }
+}
+
+impl<'root> Display for MapCallReply<'root> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.write_str("{")?;
+
+        self.iter()
+            .enumerate()
+            .try_for_each(|(index, (key, val))| -> fmt::Result {
+                if index > 1 {
+                    f.write_str(", ")?;
+                }
+                f.write_str("")?;
+                fmt_call_result(key, f)?;
+                f.write_str(": ")?;
+                fmt_call_result(val, f)
+            })?;
+
+        f.write_str("}")
     }
 }
 
@@ -287,8 +384,27 @@ impl<'root> Drop for SetCallReply<'root> {
 
 impl<'root> Debug for SetCallReply<'root> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        let elements: Vec<CallResult> = self.iter().collect();
-        write!(f, "{:?}", elements)
+        f.debug_struct("SetCallReply")
+            .field("reply", &self.reply)
+            .field("elements", &self.iter().collect::<Vec<CallResult>>())
+            .finish()
+    }
+}
+
+impl<'root> Display for SetCallReply<'root> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.write_str("{")?;
+
+        self.iter()
+            .enumerate()
+            .try_for_each(|(index, v)| -> fmt::Result {
+                if index > 1 {
+                    f.write_str(", ")?;
+                }
+                fmt_call_result(v, f)
+            })?;
+
+        f.write_str("}")
     }
 }
 
@@ -312,7 +428,16 @@ impl<'root> Drop for BoolCallReply<'root> {
 
 impl<'root> Debug for BoolCallReply<'root> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "{:?}", self.to_bool())
+        f.debug_struct("BoolCallReply")
+            .field("reply", &self.reply)
+            .field("value", &self.to_bool())
+            .finish()
+    }
+}
+
+impl<'root> Display for BoolCallReply<'root> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.to_bool(), f)
     }
 }
 
@@ -336,7 +461,16 @@ impl<'root> Drop for DoubleCallReply<'root> {
 
 impl<'root> Debug for DoubleCallReply<'root> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "{:?}", self.to_double())
+        f.debug_struct("DoubleCallReply")
+            .field("reply", &self.reply)
+            .field("value", &self.to_double())
+            .finish()
+    }
+}
+
+impl<'root> Display for DoubleCallReply<'root> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.to_double(), f)
     }
 }
 
@@ -361,7 +495,22 @@ impl<'root> Drop for BigNumberCallReply<'root> {
 
 impl<'root> Debug for BigNumberCallReply<'root> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "{:?}", self.to_string())
+        f.debug_struct("BigNumberCallReply")
+            .field("reply", &self.reply)
+            .field("value", &self.to_string())
+            .finish()
+    }
+}
+
+impl<'root> Display for BigNumberCallReply<'root> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(
+            self.to_string()
+                .as_ref()
+                .map(|v| v.as_str())
+                .unwrap_or("None"),
+            f,
+        )
     }
 }
 
@@ -409,7 +558,19 @@ impl<'root> Drop for VerbatimStringCallReply<'root> {
 
 impl<'root> Debug for VerbatimStringCallReply<'root> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "{:?}", self.to_parts())
+        f.debug_struct("VerbatimStringCallReply")
+            .field("reply", &self.reply)
+            .field("value", &self.as_parts())
+            .finish()
+    }
+}
+
+impl<'root> Display for VerbatimStringCallReply<'root> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self.as_parts() {
+            Some((format, data)) => write!(f, "({}, {})", format, String::from_utf8_lossy(data)),
+            None => f.write_str("(None)"),
+        }
     }
 }
 
@@ -426,6 +587,24 @@ pub enum CallReply<'root> {
     Double(DoubleCallReply<'root>),
     BigNumber(BigNumberCallReply<'root>),
     VerbatimString(VerbatimStringCallReply<'root>),
+}
+
+impl<'root> Display for CallReply<'root> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            CallReply::Unknown => f.write_str("Unknown"),
+            CallReply::I64(inner) => fmt::Display::fmt(&inner, f),
+            CallReply::String(inner) => fmt::Display::fmt(&inner, f),
+            CallReply::Array(inner) => fmt::Display::fmt(&inner, f),
+            CallReply::Null(inner) => fmt::Display::fmt(&inner, f),
+            CallReply::Map(inner) => fmt::Display::fmt(&inner, f),
+            CallReply::Set(inner) => fmt::Display::fmt(&inner, f),
+            CallReply::Bool(inner) => fmt::Display::fmt(&inner, f),
+            CallReply::Double(inner) => fmt::Display::fmt(&inner, f),
+            CallReply::BigNumber(inner) => fmt::Display::fmt(&inner, f),
+            CallReply::VerbatimString(inner) => fmt::Display::fmt(&inner, f),
+        }
+    }
 }
 
 fn create_call_reply<'root>(reply: NonNull<RedisModuleCallReply>) -> CallResult<'root> {
@@ -483,6 +662,13 @@ pub(crate) fn create_root_call_reply<'root>(
     reply: Option<NonNull<RedisModuleCallReply>>,
 ) -> CallResult<'root> {
     reply.map_or(Ok(CallReply::Unknown), |v| create_call_reply(v))
+}
+
+fn fmt_call_result(res: CallResult<'_>, f: &mut Formatter<'_>) -> fmt::Result {
+    match res {
+        Ok(r) => fmt::Display::fmt(&r, f),
+        Err(e) => fmt::Display::fmt(&e, f),
+    }
 }
 
 pub type CallResult<'root> = Result<CallReply<'root>, ErrorCallReply<'root>>;

--- a/src/context/call_reply.rs
+++ b/src/context/call_reply.rs
@@ -52,11 +52,8 @@ impl<'root> Debug for StringCallReply<'root> {
 impl<'root> Display for StringCallReply<'root> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(
-            self.to_string()
-                .as_ref()
-                .map(|v| v.as_str())
-                .unwrap_or("None"),
-            f,
+            &String::from_utf8_lossy(self.as_bytes()),
+            f
         )
     }
 }
@@ -104,10 +101,7 @@ impl<'root> Debug for ErrorCallReply<'root> {
 impl<'root> Display for ErrorCallReply<'root> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(
-            self.to_string()
-                .as_ref()
-                .map(|v| v.as_str())
-                .unwrap_or("None"),
+            &String::from_utf8_lossy(self.as_bytes()),
             f,
         )
     }

--- a/src/context/call_reply.rs
+++ b/src/context/call_reply.rs
@@ -1,4 +1,5 @@
-use std::{ptr::NonNull, marker::PhantomData};
+use core::slice;
+use std::{ffi::c_char, marker::PhantomData, ptr::NonNull};
 
 use crate::raw::*;
 
@@ -8,8 +9,19 @@ pub struct StringCallReply<'root> {
 }
 
 impl<'root> StringCallReply<'root> {
+    /// Convert StringCallReply to String.
+    /// Return None data is not a valid utf8.
     pub fn to_string(&self) -> Option<String> {
-        call_reply_string(self.reply.as_ptr())
+        String::from_utf8(self.as_bytes().to_vec()).ok()
+    }
+
+    /// Return the StringCallReply data as &[u8]
+    pub fn as_bytes(&self) -> &[u8] {
+        let mut len: usize = 0;
+        let reply_string: *mut u8 = unsafe {
+            RedisModule_CallReplyStringPtr.unwrap()(self.reply.as_ptr(), &mut len) as *mut u8
+        };
+        unsafe { slice::from_raw_parts(reply_string, len) }
     }
 }
 
@@ -25,8 +37,19 @@ pub struct ErrorCallReply<'root> {
 }
 
 impl<'root> ErrorCallReply<'root> {
+    /// Convert ErrorCallReply to String.
+    /// Return None data is not a valid utf8.
     pub fn to_string(&self) -> Option<String> {
-        call_reply_string(self.reply.as_ptr())
+        String::from_utf8(self.as_bytes().to_vec()).ok()
+    }
+
+    /// Return the ErrorCallReply data as &[u8]
+    pub fn as_bytes(&self) -> &[u8] {
+        let mut len: usize = 0;
+        let reply_string: *mut u8 = unsafe {
+            RedisModule_CallReplyStringPtr.unwrap()(self.reply.as_ptr(), &mut len) as *mut u8
+        };
+        unsafe { slice::from_raw_parts(reply_string, len) }
     }
 }
 
@@ -42,6 +65,7 @@ pub struct I64CallReply<'root> {
 }
 
 impl<'root> I64CallReply<'root> {
+    /// Return the i64 value of the [I64CallReply]
     pub fn to_i64(&self) -> i64 {
         call_reply_integer(self.reply.as_ptr())
     }
@@ -65,18 +89,22 @@ impl<'root> Drop for ArrayCallReply<'root> {
 }
 
 impl<'root> ArrayCallReply<'root> {
+    /// Return an Iterator that allows to iterate over the elements
+    /// in the [ArrayCallReply].
     pub fn iter(&self) -> ArrayCallReplyIterator<'root, '_> {
-        ArrayCallReplyIterator{
+        ArrayCallReplyIterator {
             reply: self,
             index: 0,
         }
     }
 
+    /// Return the array element on the given index.
     pub fn get(&self, idx: usize) -> Option<CallReply<'_>> {
         let res = NonNull::new(call_reply_array_element(self.reply.as_ptr(), idx))?;
         Some(create_call_reply(res))
     }
 
+    /// Return the number of elements in the [ArrayCallReply].
     pub fn len(&self) -> usize {
         call_reply_length(self.reply.as_ptr())
     }
@@ -116,18 +144,26 @@ pub struct MapCallReply<'root> {
 }
 
 impl<'root> MapCallReply<'root> {
+    /// Return an iterator over the elements in the [MapCallReply].
+    /// The iterator return each element as a tuple representing the
+    /// key and the value.
     pub fn iter(&self) -> MapCallReplyIterator<'root, '_> {
-        MapCallReplyIterator{
+        MapCallReplyIterator {
             reply: self,
             index: 0,
         }
     }
 
+    /// Return the map element on the given index.
     pub fn get(&self, idx: usize) -> Option<(CallReply<'_>, CallReply<'_>)> {
         let (key, val) = call_reply_map_element(self.reply.as_ptr(), idx);
-        Some((create_call_reply(NonNull::new(key)?), create_call_reply(NonNull::new(val)?))) 
+        Some((
+            create_call_reply(NonNull::new(key)?),
+            create_call_reply(NonNull::new(val)?),
+        ))
     }
 
+    /// Return the number of elements in the [MapCallReply].
     pub fn len(&self) -> usize {
         call_reply_length(self.reply.as_ptr())
     }
@@ -162,18 +198,21 @@ pub struct SetCallReply<'root> {
 }
 
 impl<'root> SetCallReply<'root> {
+    /// Return an iterator over the elements in the [SetCallReply].
     pub fn iter(&self) -> SetCallReplyIterator<'root, '_> {
-        SetCallReplyIterator{
+        SetCallReplyIterator {
             reply: self,
             index: 0,
         }
     }
 
+    /// Return the set element on the given index.
     pub fn get(&self, idx: usize) -> Option<CallReply<'_>> {
         let res = NonNull::new(call_reply_set_element(self.reply.as_ptr(), idx))?;
         Some(create_call_reply(res))
     }
 
+    /// Return the number of elements in the [SetCallReply].
     pub fn len(&self) -> usize {
         call_reply_length(self.reply.as_ptr())
     }
@@ -208,6 +247,7 @@ pub struct BoolCallReply<'root> {
 }
 
 impl<'root> BoolCallReply<'root> {
+    /// Return the boolean value of the [BoolCallReply].
     pub fn to_bool(&self) -> bool {
         call_reply_bool(self.reply.as_ptr())
     }
@@ -225,6 +265,7 @@ pub struct DoubleCallReply<'root> {
 }
 
 impl<'root> DoubleCallReply<'root> {
+    /// Return the double value of the [BoolCallReply] as f64.
     pub fn to_double(&self) -> f64 {
         call_reply_double(self.reply.as_ptr())
     }
@@ -242,6 +283,8 @@ pub struct BigNumberCallReply<'root> {
 }
 
 impl<'root> BigNumberCallReply<'root> {
+    /// Return the big number value of the [BigNumberCallReply] as String.
+    /// Return None if the data is not a valid utf8
     pub fn to_string(&self) -> Option<String> {
         call_reply_big_number(self.reply.as_ptr())
     }
@@ -259,8 +302,33 @@ pub struct VerbatimStringCallReply<'root> {
 }
 
 impl<'root> VerbatimStringCallReply<'root> {
+    /// Return the verbatim string value of the [VerbatimStringCallReply] as a tuple.
+    /// The first entry represents the format, the second entry represent the data.
+    /// Return None if the format is not a valid utf8
     pub fn to_parts(&self) -> Option<(String, Vec<u8>)> {
-        call_reply_verbatim_string(self.reply.as_ptr())
+        self.as_parts()
+            .map(|(format, data)| (format.to_string(), data.to_vec()))
+    }
+
+    /// Borrow the verbatim string value of the [VerbatimStringCallReply] as a tuple.
+    /// The first entry represents the format as &str, the second entry represent the data as &[u8].
+    /// Return None if the format is not a valid utf8.
+    pub fn as_parts(&self) -> Option<(&str, &[u8])> {
+        let mut len: usize = 0;
+        let format: *const u8 = std::ptr::null();
+        let reply_string: *mut u8 = unsafe {
+            RedisModule_CallReplyVerbatim.unwrap()(
+                self.reply.as_ptr(),
+                &mut len,
+                &mut (format as *const c_char),
+            ) as *mut u8
+        };
+        Some((
+            std::str::from_utf8(unsafe { slice::from_raw_parts(format, 3) })
+                .ok()
+                .unwrap(),
+            unsafe { slice::from_raw_parts(reply_string, len) },
+        ))
     }
 }
 
@@ -289,20 +357,55 @@ fn create_call_reply<'root>(reply: NonNull<RedisModuleCallReply>) -> CallReply<'
     let ty = call_reply_type(reply.as_ptr());
     match ty {
         ReplyType::Unknown => CallReply::Unknown, // unknown means NULL so no need to free free anything
-        ReplyType::Integer => CallReply::I64(I64CallReply{ reply: reply, _dummy: PhantomData}),
-        ReplyType::String => CallReply::String(StringCallReply{ reply: reply, _dummy: PhantomData}),
-        ReplyType::Error => CallReply::Error(ErrorCallReply{ reply: reply, _dummy: PhantomData}),
-        ReplyType::Array => CallReply::Array(ArrayCallReply{ reply: reply, _dummy: PhantomData}),
-        ReplyType::Null => CallReply::Null(NullCallReply{ reply: reply, _dummy: PhantomData}),
-        ReplyType::Map => CallReply::Map(MapCallReply{ reply: reply, _dummy: PhantomData}),
-        ReplyType::Set => CallReply::Set(SetCallReply{ reply: reply, _dummy: PhantomData}),
-        ReplyType::Bool => CallReply::Bool(BoolCallReply{ reply: reply, _dummy: PhantomData}),
-        ReplyType::Double => CallReply::Double(DoubleCallReply{ reply: reply, _dummy: PhantomData}),
-        ReplyType::BigNumber => CallReply::BigNumber(BigNumberCallReply{ reply: reply, _dummy: PhantomData}),
-        ReplyType::VerbatimString => CallReply::VerbatimString(VerbatimStringCallReply{ reply: reply, _dummy: PhantomData}),
+        ReplyType::Integer => CallReply::I64(I64CallReply {
+            reply: reply,
+            _dummy: PhantomData,
+        }),
+        ReplyType::String => CallReply::String(StringCallReply {
+            reply: reply,
+            _dummy: PhantomData,
+        }),
+        ReplyType::Error => CallReply::Error(ErrorCallReply {
+            reply: reply,
+            _dummy: PhantomData,
+        }),
+        ReplyType::Array => CallReply::Array(ArrayCallReply {
+            reply: reply,
+            _dummy: PhantomData,
+        }),
+        ReplyType::Null => CallReply::Null(NullCallReply {
+            reply: reply,
+            _dummy: PhantomData,
+        }),
+        ReplyType::Map => CallReply::Map(MapCallReply {
+            reply: reply,
+            _dummy: PhantomData,
+        }),
+        ReplyType::Set => CallReply::Set(SetCallReply {
+            reply: reply,
+            _dummy: PhantomData,
+        }),
+        ReplyType::Bool => CallReply::Bool(BoolCallReply {
+            reply: reply,
+            _dummy: PhantomData,
+        }),
+        ReplyType::Double => CallReply::Double(DoubleCallReply {
+            reply: reply,
+            _dummy: PhantomData,
+        }),
+        ReplyType::BigNumber => CallReply::BigNumber(BigNumberCallReply {
+            reply: reply,
+            _dummy: PhantomData,
+        }),
+        ReplyType::VerbatimString => CallReply::VerbatimString(VerbatimStringCallReply {
+            reply: reply,
+            _dummy: PhantomData,
+        }),
     }
 }
 
-pub(crate) fn create_root_call_reply<'root>(reply: Option<NonNull<RedisModuleCallReply>>) -> CallReply<'root> {
+pub(crate) fn create_root_call_reply<'root>(
+    reply: Option<NonNull<RedisModuleCallReply>>,
+) -> CallReply<'root> {
     reply.map_or(CallReply::Unknown, |v| create_call_reply(v))
 }

--- a/src/context/call_reply.rs
+++ b/src/context/call_reply.rs
@@ -51,10 +51,7 @@ impl<'root> Debug for StringCallReply<'root> {
 
 impl<'root> Display for StringCallReply<'root> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        fmt::Display::fmt(
-            &String::from_utf8_lossy(self.as_bytes()),
-            f
-        )
+        fmt::Display::fmt(&String::from_utf8_lossy(self.as_bytes()), f)
     }
 }
 
@@ -100,10 +97,7 @@ impl<'root> Debug for ErrorCallReply<'root> {
 
 impl<'root> Display for ErrorCallReply<'root> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        fmt::Display::fmt(
-            &String::from_utf8_lossy(self.as_bytes()),
-            f,
-        )
+        fmt::Display::fmt(&String::from_utf8_lossy(self.as_bytes()), f)
     }
 }
 

--- a/src/context/call_reply.rs
+++ b/src/context/call_reply.rs
@@ -37,6 +37,12 @@ impl<'root> Drop for StringCallReply<'root> {
     }
 }
 
+impl<'root> Debug for StringCallReply<'root> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self.as_bytes())
+    }
+}
+
 pub struct ErrorCallReply<'root> {
     reply: NonNull<RedisModuleCallReply>,
     _dummy: PhantomData<&'root ()>,
@@ -59,20 +65,15 @@ impl<'root> ErrorCallReply<'root> {
     }
 }
 
-impl<'root> Debug for ErrorCallReply<'root> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "ErrorCallReply: {}.",
-            self.to_string()
-                .unwrap_or("can not transform data into String".to_string())
-        )
-    }
-}
-
 impl<'root> Drop for ErrorCallReply<'root> {
     fn drop(&mut self) {
         free_call_reply(self.reply.as_ptr());
+    }
+}
+
+impl<'root> Debug for ErrorCallReply<'root> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self.to_string())
     }
 }
 
@@ -91,6 +92,12 @@ impl<'root> I64CallReply<'root> {
 impl<'root> Drop for I64CallReply<'root> {
     fn drop(&mut self) {
         free_call_reply(self.reply.as_ptr());
+    }
+}
+
+impl<'root> Debug for I64CallReply<'root> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self.to_i64())
     }
 }
 
@@ -144,6 +151,13 @@ impl<'root, 'curr> Iterator for ArrayCallReplyIterator<'root, 'curr> {
     }
 }
 
+impl<'root> Debug for ArrayCallReply<'root> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        let children: Vec<CallResult> = self.iter().collect();
+        write!(f, "{:?}", children)
+    }
+}
+
 pub struct NullCallReply<'root> {
     reply: NonNull<RedisModuleCallReply>,
     _dummy: PhantomData<&'root ()>,
@@ -152,6 +166,12 @@ pub struct NullCallReply<'root> {
 impl<'root> Drop for NullCallReply<'root> {
     fn drop(&mut self) {
         free_call_reply(self.reply.as_ptr());
+    }
+}
+
+impl<'root> Debug for NullCallReply<'root> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "Null")
     }
 }
 
@@ -209,6 +229,13 @@ impl<'root> Drop for MapCallReply<'root> {
     }
 }
 
+impl<'root> Debug for MapCallReply<'root> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        let elements: Vec<(CallResult, CallResult)> = self.iter().collect();
+        write!(f, "{:?}", elements)
+    }
+}
+
 pub struct SetCallReply<'root> {
     reply: NonNull<RedisModuleCallReply>,
     _dummy: PhantomData<&'root ()>,
@@ -258,6 +285,13 @@ impl<'root> Drop for SetCallReply<'root> {
     }
 }
 
+impl<'root> Debug for SetCallReply<'root> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        let elements: Vec<CallResult> = self.iter().collect();
+        write!(f, "{:?}", elements)
+    }
+}
+
 pub struct BoolCallReply<'root> {
     reply: NonNull<RedisModuleCallReply>,
     _dummy: PhantomData<&'root ()>,
@@ -273,6 +307,12 @@ impl<'root> BoolCallReply<'root> {
 impl<'root> Drop for BoolCallReply<'root> {
     fn drop(&mut self) {
         free_call_reply(self.reply.as_ptr());
+    }
+}
+
+impl<'root> Debug for BoolCallReply<'root> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self.to_bool())
     }
 }
 
@@ -294,6 +334,12 @@ impl<'root> Drop for DoubleCallReply<'root> {
     }
 }
 
+impl<'root> Debug for DoubleCallReply<'root> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self.to_double())
+    }
+}
+
 pub struct BigNumberCallReply<'root> {
     reply: NonNull<RedisModuleCallReply>,
     _dummy: PhantomData<&'root ()>,
@@ -310,6 +356,12 @@ impl<'root> BigNumberCallReply<'root> {
 impl<'root> Drop for BigNumberCallReply<'root> {
     fn drop(&mut self) {
         free_call_reply(self.reply.as_ptr());
+    }
+}
+
+impl<'root> Debug for BigNumberCallReply<'root> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self.to_string())
     }
 }
 
@@ -355,6 +407,13 @@ impl<'root> Drop for VerbatimStringCallReply<'root> {
     }
 }
 
+impl<'root> Debug for VerbatimStringCallReply<'root> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self.to_parts())
+    }
+}
+
+#[derive(Debug)]
 pub enum CallReply<'root> {
     Unknown,
     I64(I64CallReply<'root>),

--- a/src/context/call_reply.rs
+++ b/src/context/call_reply.rs
@@ -1,170 +1,94 @@
-use std::{ffi::c_longlong, ptr::NonNull};
+use std::{ptr::NonNull, marker::PhantomData};
 
 use crate::raw::*;
 
-pub trait CallReply {
-    /// Return the call reply type
-    fn get_type(&self) -> ReplyType;
-
-    /// Return the reply us rust string,
-    /// Only relevant to the following types:
-    /// * String
-    /// * Error
-    ///
-    /// A none will also be returned if failed to convert the
-    /// data into a string (data is binary).
-    fn get_string(&self) -> Option<String>;
-
-    /// Return lenght of the reply,
-    /// Only relevant to the following types:
-    /// * String
-    /// * Error
-    /// * Array
-    ///
-    /// Running this function on other type will return 0.
-    fn len(&self) -> usize;
-
-    /// Return the reply at the location of the given index,
-    /// Only relevant to the following types:
-    /// * Array
-    ///
-    /// Running this function on other type will return None.
-    fn get(&self, index: usize) -> Option<InnerCallReply>;
-
-    /// Return an iterator over the elements in the array
-    /// Only relevant to the following types:
-    /// * Array
-    ///
-    /// Running this function on other type will return an empty iterator.
-    fn iter(&self) -> Box<dyn Iterator<Item = InnerCallReply> + '_>;
-
-    /// Return integer value of the reply type
-    /// Only relevant to the following types:
-    /// * Integer
-    ///
-    /// Running this function on other type will return 0.
-    fn get_int(&self) -> c_longlong;
-}
-
-pub struct RootCallReply {
-    reply: Option<NonNull<RedisModuleCallReply>>,
-}
-
-impl RootCallReply {
-    pub(crate) fn new(reply: *mut RedisModuleCallReply) -> RootCallReply {
-        RootCallReply {
-            reply: NonNull::new(reply),
-        }
-    }
-}
-
-impl CallReply for RootCallReply {
-    fn get_type(&self) -> ReplyType {
-        self.reply
-            .map_or(ReplyType::Unknown, |e| call_reply_type(e.as_ptr()))
-    }
-
-    fn get_string(&self) -> Option<String> {
-        call_reply_string(self.reply?.as_ptr())
-    }
-
-    fn len(&self) -> usize {
-        self.reply.map_or(0, |e| call_reply_length(e.as_ptr()))
-    }
-
-    fn get(&self, index: usize) -> Option<InnerCallReply> {
-        // Redis will verify array boundaries so no need to veirfy it here.
-        NonNull::new(call_reply_array_element(self.reply?.as_ptr(), index))
-            .map(|inner_reply| InnerCallReply::new(self, inner_reply))
-    }
-
-    fn iter(&self) -> Box<dyn Iterator<Item = InnerCallReply> + '_> {
-        Box::new(RootCallReplyIterator {
-            reply: self,
-            index: 0,
-        })
-    }
-
-    fn get_int(&self) -> c_longlong {
-        self.reply.map_or(0, |e| call_reply_integer(e.as_ptr()))
-    }
-}
-
-impl Drop for RootCallReply {
-    fn drop(&mut self) {
-        self.reply.map(|e| free_call_reply(e.as_ptr()));
-    }
-}
-
-pub struct RootCallReplyIterator<'root> {
-    reply: &'root RootCallReply,
-    index: usize,
-}
-
-impl<'root> Iterator for RootCallReplyIterator<'root> {
-    type Item = InnerCallReply<'root>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        let res = self.reply.get(self.index);
-        if res.is_some() {
-            self.index += 1;
-        }
-        res
-    }
-}
-
-pub struct InnerCallReply<'root> {
-    root: &'root RootCallReply,
+pub struct StringCallReply<'root> {
     reply: NonNull<RedisModuleCallReply>,
+    _dummy: PhantomData<&'root i64>,
 }
 
-impl<'root> InnerCallReply<'root> {
-    pub(crate) fn new(
-        root: &'root RootCallReply,
-        reply: NonNull<RedisModuleCallReply>,
-    ) -> InnerCallReply<'root> {
-        InnerCallReply { root, reply }
-    }
-}
-
-impl<'a> CallReply for InnerCallReply<'a> {
-    fn get_type(&self) -> ReplyType {
-        call_reply_type(self.reply.as_ptr())
-    }
-
-    fn get_string(&self) -> Option<String> {
+impl<'root> StringCallReply<'root> {
+    pub fn to_string(&self) -> Option<String> {
         call_reply_string(self.reply.as_ptr())
     }
+}
 
-    fn len(&self) -> usize {
-        call_reply_length(self.reply.as_ptr())
+impl<'root> Drop for StringCallReply<'root> {
+    fn drop(&mut self) {
+        free_call_reply(self.reply.as_ptr());
     }
+}
 
-    fn get(&self, index: usize) -> Option<Self> {
-        // Redis will verify array boundaries so no need to veirfy it here.
-        NonNull::new(call_reply_array_element(self.reply.as_ptr(), index))
-            .map(|inner_reply| Self::new(self.root, inner_reply))
+pub struct ErrorCallReply<'root> {
+    reply: NonNull<RedisModuleCallReply>,
+    _dummy: PhantomData<&'root i64>,
+}
+
+impl<'root> ErrorCallReply<'root> {
+    pub fn to_string(&self) -> Option<String> {
+        call_reply_string(self.reply.as_ptr())
     }
+}
 
-    fn iter(&self) -> Box<dyn Iterator<Item = InnerCallReply> + '_> {
-        Box::new(InnerCallReplyIterator {
-            reply: self,
-            index: 0,
-        })
+impl<'root> Drop for ErrorCallReply<'root> {
+    fn drop(&mut self) {
+        free_call_reply(self.reply.as_ptr());
     }
+}
 
-    fn get_int(&self) -> c_longlong {
+pub struct I64CallReply<'root> {
+    reply: NonNull<RedisModuleCallReply>,
+    _dummy: PhantomData<&'root i64>,
+}
+
+impl<'root> I64CallReply<'root> {
+    pub fn to_i64(&self) -> i64 {
         call_reply_integer(self.reply.as_ptr())
     }
 }
 
-pub struct InnerCallReplyIterator<'root, 'curr: 'root> {
-    reply: &'curr InnerCallReply<'root>,
+impl<'root> Drop for I64CallReply<'root> {
+    fn drop(&mut self) {
+        free_call_reply(self.reply.as_ptr());
+    }
+}
+
+pub struct ArrayCallReply<'root> {
+    reply: NonNull<RedisModuleCallReply>,
+    _dummy: PhantomData<&'root i64>,
+}
+
+impl<'root> Drop for ArrayCallReply<'root> {
+    fn drop(&mut self) {
+        free_call_reply(self.reply.as_ptr());
+    }
+}
+
+impl<'root> ArrayCallReply<'root> {
+    pub fn iter(&self) -> ArrayCallReplyIterator<'root, '_> {
+        ArrayCallReplyIterator{
+            reply: self,
+            index: 0,
+        }
+    }
+
+    pub fn get(&self, idx: usize) -> Option<CallReply<'_>> {
+        let res = NonNull::new(call_reply_array_element(self.reply.as_ptr(), idx))?;
+        Some(create_call_reply(res))
+    }
+
+    pub fn len(&self) -> usize {
+        call_reply_length(self.reply.as_ptr())
+    }
+}
+
+pub struct ArrayCallReplyIterator<'root, 'curr> {
+    reply: &'curr ArrayCallReply<'root>,
     index: usize,
 }
 
-impl<'root, 'curr: 'root> Iterator for InnerCallReplyIterator<'root, 'curr> {
-    type Item = InnerCallReply<'root>;
+impl<'root, 'curr> Iterator for ArrayCallReplyIterator<'root, 'curr> {
+    type Item = CallReply<'curr>;
 
     fn next(&mut self) -> Option<Self::Item> {
         let res = self.reply.get(self.index);
@@ -173,4 +97,212 @@ impl<'root, 'curr: 'root> Iterator for InnerCallReplyIterator<'root, 'curr> {
         }
         res
     }
+}
+
+pub struct NullCallReply<'root> {
+    reply: NonNull<RedisModuleCallReply>,
+    _dummy: PhantomData<&'root i64>,
+}
+
+impl<'root> Drop for NullCallReply<'root> {
+    fn drop(&mut self) {
+        free_call_reply(self.reply.as_ptr());
+    }
+}
+
+pub struct MapCallReply<'root> {
+    reply: NonNull<RedisModuleCallReply>,
+    _dummy: PhantomData<&'root i64>,
+}
+
+impl<'root> MapCallReply<'root> {
+    pub fn iter(&self) -> MapCallReplyIterator<'root, '_> {
+        MapCallReplyIterator{
+            reply: self,
+            index: 0,
+        }
+    }
+
+    pub fn get(&self, idx: usize) -> Option<(CallReply<'_>, CallReply<'_>)> {
+        let (key, val) = call_reply_map_element(self.reply.as_ptr(), idx);
+        Some((create_call_reply(NonNull::new(key)?), create_call_reply(NonNull::new(val)?))) 
+    }
+
+    pub fn len(&self) -> usize {
+        call_reply_length(self.reply.as_ptr())
+    }
+}
+
+pub struct MapCallReplyIterator<'root, 'curr> {
+    reply: &'curr MapCallReply<'root>,
+    index: usize,
+}
+
+impl<'root, 'curr> Iterator for MapCallReplyIterator<'root, 'curr> {
+    type Item = (CallReply<'curr>, CallReply<'curr>);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let res = self.reply.get(self.index);
+        if res.is_some() {
+            self.index += 1;
+        }
+        res
+    }
+}
+
+impl<'root> Drop for MapCallReply<'root> {
+    fn drop(&mut self) {
+        free_call_reply(self.reply.as_ptr());
+    }
+}
+
+pub struct SetCallReply<'root> {
+    reply: NonNull<RedisModuleCallReply>,
+    _dummy: PhantomData<&'root i64>,
+}
+
+impl<'root> SetCallReply<'root> {
+    pub fn iter(&self) -> SetCallReplyIterator<'root, '_> {
+        SetCallReplyIterator{
+            reply: self,
+            index: 0,
+        }
+    }
+
+    pub fn get(&self, idx: usize) -> Option<CallReply<'_>> {
+        let res = NonNull::new(call_reply_set_element(self.reply.as_ptr(), idx))?;
+        Some(create_call_reply(res))
+    }
+
+    pub fn len(&self) -> usize {
+        call_reply_length(self.reply.as_ptr())
+    }
+}
+
+pub struct SetCallReplyIterator<'root, 'curr> {
+    reply: &'curr SetCallReply<'root>,
+    index: usize,
+}
+
+impl<'root, 'curr> Iterator for SetCallReplyIterator<'root, 'curr> {
+    type Item = CallReply<'curr>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let res = self.reply.get(self.index);
+        if res.is_some() {
+            self.index += 1;
+        }
+        res
+    }
+}
+
+impl<'root> Drop for SetCallReply<'root> {
+    fn drop(&mut self) {
+        free_call_reply(self.reply.as_ptr());
+    }
+}
+
+pub struct BoolCallReply<'root> {
+    reply: NonNull<RedisModuleCallReply>,
+    _dummy: PhantomData<&'root i64>,
+}
+
+impl<'root> BoolCallReply<'root> {
+    pub fn to_bool(&self) -> bool {
+        call_reply_bool(self.reply.as_ptr())
+    }
+}
+
+impl<'root> Drop for BoolCallReply<'root> {
+    fn drop(&mut self) {
+        free_call_reply(self.reply.as_ptr());
+    }
+}
+
+pub struct DoubleCallReply<'root> {
+    reply: NonNull<RedisModuleCallReply>,
+    _dummy: PhantomData<&'root i64>,
+}
+
+impl<'root> DoubleCallReply<'root> {
+    pub fn to_double(&self) -> f64 {
+        call_reply_double(self.reply.as_ptr())
+    }
+}
+
+impl<'root> Drop for DoubleCallReply<'root> {
+    fn drop(&mut self) {
+        free_call_reply(self.reply.as_ptr());
+    }
+}
+
+pub struct BigNumberCallReply<'root> {
+    reply: NonNull<RedisModuleCallReply>,
+    _dummy: PhantomData<&'root i64>,
+}
+
+impl<'root> BigNumberCallReply<'root> {
+    pub fn to_string(&self) -> Option<String> {
+        call_reply_big_number(self.reply.as_ptr())
+    }
+}
+
+impl<'root> Drop for BigNumberCallReply<'root> {
+    fn drop(&mut self) {
+        free_call_reply(self.reply.as_ptr());
+    }
+}
+
+pub struct VerbatimStringCallReply<'root> {
+    reply: NonNull<RedisModuleCallReply>,
+    _dummy: PhantomData<&'root i64>,
+}
+
+impl<'root> VerbatimStringCallReply<'root> {
+    pub fn to_parts(&self) -> Option<(String, Vec<u8>)> {
+        call_reply_verbatim_string(self.reply.as_ptr())
+    }
+}
+
+impl<'root> Drop for VerbatimStringCallReply<'root> {
+    fn drop(&mut self) {
+        free_call_reply(self.reply.as_ptr());
+    }
+}
+
+pub enum CallReply<'root> {
+    Unknown,
+    I64(I64CallReply<'root>),
+    String(StringCallReply<'root>),
+    Error(ErrorCallReply<'root>),
+    Array(ArrayCallReply<'root>),
+    Null(NullCallReply<'root>),
+    Map(MapCallReply<'root>),
+    Set(SetCallReply<'root>),
+    Bool(BoolCallReply<'root>),
+    Double(DoubleCallReply<'root>),
+    BigNumber(BigNumberCallReply<'root>),
+    VerbatimString(VerbatimStringCallReply<'root>),
+}
+
+fn create_call_reply<'root>(reply: NonNull<RedisModuleCallReply>) -> CallReply<'root> {
+    let ty = call_reply_type(reply.as_ptr());
+    match ty {
+        ReplyType::Unknown => CallReply::Unknown, // unknown means NULL so no need to free free anything
+        ReplyType::Integer => CallReply::I64(I64CallReply{ reply: reply, _dummy: PhantomData}),
+        ReplyType::String => CallReply::String(StringCallReply{ reply: reply, _dummy: PhantomData}),
+        ReplyType::Error => CallReply::Error(ErrorCallReply{ reply: reply, _dummy: PhantomData}),
+        ReplyType::Array => CallReply::Array(ArrayCallReply{ reply: reply, _dummy: PhantomData}),
+        ReplyType::Null => CallReply::Null(NullCallReply{ reply: reply, _dummy: PhantomData}),
+        ReplyType::Map => CallReply::Map(MapCallReply{ reply: reply, _dummy: PhantomData}),
+        ReplyType::Set => CallReply::Set(SetCallReply{ reply: reply, _dummy: PhantomData}),
+        ReplyType::Bool => CallReply::Bool(BoolCallReply{ reply: reply, _dummy: PhantomData}),
+        ReplyType::Double => CallReply::Double(DoubleCallReply{ reply: reply, _dummy: PhantomData}),
+        ReplyType::BigNumber => CallReply::BigNumber(BigNumberCallReply{ reply: reply, _dummy: PhantomData}),
+        ReplyType::VerbatimString => CallReply::VerbatimString(VerbatimStringCallReply{ reply: reply, _dummy: PhantomData}),
+    }
+}
+
+pub(crate) fn create_root_call_reply<'root>(reply: Option<NonNull<RedisModuleCallReply>>) -> CallReply<'root> {
+    reply.map_or(CallReply::Unknown, |v| create_call_reply(v))
 }

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -331,14 +331,18 @@ impl Context {
                 raw::reply_with_string_buffer(self.ctx, s.as_ptr().cast::<c_char>(), s.len())
             }
 
-            Ok(RedisValue::BigNumber(s)) =>{
+            Ok(RedisValue::BigNumber(s)) => {
                 raw::reply_with_big_number(self.ctx, s.as_ptr().cast::<c_char>(), s.len())
             }
 
-            Ok(RedisValue::VerbatimString((format, mut data))) =>{
+            Ok(RedisValue::VerbatimString((format, mut data))) => {
                 let mut final_data = format.as_bytes().to_vec();
                 final_data.append(&mut data);
-                raw::reply_with_verbatim_string(self.ctx, final_data.as_ptr().cast::<c_char>(), final_data.len())
+                raw::reply_with_verbatim_string(
+                    self.ctx,
+                    final_data.as_ptr().cast::<c_char>(),
+                    final_data.len(),
+                )
             }
 
             Ok(RedisValue::BulkRedisString(s)) => raw::reply_with_string(self.ctx, s.inner),

--- a/src/include/redismodule.h
+++ b/src/include/redismodule.h
@@ -1045,7 +1045,7 @@ REDISMODULE_API int (*RedisModule_StringAppendBuffer)(RedisModuleCtx *ctx, Redis
 REDISMODULE_API void (*RedisModule_TrimStringAllocation)(RedisModuleString *str) REDISMODULE_ATTR;
 REDISMODULE_API void (*RedisModule_RetainString)(RedisModuleCtx *ctx, RedisModuleString *str) REDISMODULE_ATTR;
 REDISMODULE_API RedisModuleString * (*RedisModule_HoldString)(RedisModuleCtx *ctx, RedisModuleString *str) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_StringCompare)(RedisModuleString *a, RedisModuleString *b) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_StringCompare)(const RedisModuleString *a, const RedisModuleString *b) REDISMODULE_ATTR;
 REDISMODULE_API RedisModuleCtx * (*RedisModule_GetContextFromIO)(RedisModuleIO *io) REDISMODULE_ATTR;
 REDISMODULE_API const RedisModuleString * (*RedisModule_GetKeyNameFromIO)(RedisModuleIO *io) REDISMODULE_ATTR;
 REDISMODULE_API const RedisModuleString * (*RedisModule_GetKeyNameFromModuleKey)(RedisModuleKey *key) REDISMODULE_ATTR;

--- a/src/include/redismodule.h
+++ b/src/include/redismodule.h
@@ -948,7 +948,7 @@ REDISMODULE_API int (*RedisModule_ReplyWithNull)(RedisModuleCtx *ctx) REDISMODUL
 REDISMODULE_API int (*RedisModule_ReplyWithBool)(RedisModuleCtx *ctx, int b) REDISMODULE_ATTR;
 // REDISMODULE_API int (*RedisModule_ReplyWithLongDouble)(RedisModuleCtx *ctx, long double d) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_ReplyWithDouble)(RedisModuleCtx *ctx, double d) REDISMODULE_ATTR;
-// REDISMODULE_API int (*RedisModule_ReplyWithBigNumber)(RedisModuleCtx *ctx, const char *bignum, size_t len) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_ReplyWithBigNumber)(RedisModuleCtx *ctx, const char *bignum, size_t len) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_ReplyWithCallReply)(RedisModuleCtx *ctx, RedisModuleCallReply *reply) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_StringToLongLong)(const RedisModuleString *str, long long *ll) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_StringToULongLong)(const RedisModuleString *str, unsigned long long *ull) REDISMODULE_ATTR;
@@ -1251,7 +1251,7 @@ static int RedisModule_Init(RedisModuleCtx *ctx, const char *name, int ver, int 
     REDISMODULE_GET_API(ReplyWithBool);
     REDISMODULE_GET_API(ReplyWithCallReply);
     REDISMODULE_GET_API(ReplyWithDouble);
-    // REDISMODULE_GET_API(ReplyWithBigNumber);
+    REDISMODULE_GET_API(ReplyWithBigNumber);
     // REDISMODULE_GET_API(ReplyWithLongDouble);
     REDISMODULE_GET_API(GetSelectedDb);
     REDISMODULE_GET_API(SelectDb);

--- a/src/include/redismodule.h
+++ b/src/include/redismodule.h
@@ -1381,7 +1381,7 @@ static int RedisModule_Init(RedisModuleCtx *ctx, const char *name, int ver, int 
     REDISMODULE_GET_API(TrimStringAllocation);
     REDISMODULE_GET_API(RetainString);
     REDISMODULE_GET_API(HoldString);
-    // REDISMODULE_GET_API(StringCompare);
+    REDISMODULE_GET_API(StringCompare);
     REDISMODULE_GET_API(GetContextFromIO);
     REDISMODULE_GET_API(GetKeyNameFromIO);
     REDISMODULE_GET_API(GetKeyNameFromModuleKey);

--- a/src/key.rs
+++ b/src/key.rs
@@ -334,9 +334,9 @@ impl RedisKeyWritable {
     /// # Panics
     ///
     /// Will panic if `RedisModule_ModuleTypeGetValue` is missing in redismodule.h
-    /// 
+    ///
     /// TODO Avoid clippy warning about needless lifetime as a temporary workaround
-    #[allow(clippy::needless_lifetimes)]    
+    #[allow(clippy::needless_lifetimes)]
     pub fn get_value<'a, 'b, T>(
         &'a self,
         redis_type: &RedisType,

--- a/src/key.rs
+++ b/src/key.rs
@@ -333,7 +333,10 @@ impl RedisKeyWritable {
 
     /// # Panics
     ///
-    /// Will panic if `RedisModule_ModuleTypeGetValue` is missing in redismodule.h    
+    /// Will panic if `RedisModule_ModuleTypeGetValue` is missing in redismodule.h
+    /// 
+    /// TODO Avoid clippy warning about needless lifetime as a temporary workaround
+    #[allow(clippy::needless_lifetimes)]    
     pub fn get_value<'a, 'b, T>(
         &'a self,
         redis_type: &RedisType,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,9 +28,9 @@ pub use crate::context::thread_safe::{DetachedFromClient, ThreadSafeContext};
 #[cfg(feature = "experimental-api")]
 pub use crate::raw::NotifyEvent;
 
-pub use crate::context::call_reply::{CallReply, CallResult};
 pub use crate::configuration::ConfigurationValue;
 pub use crate::configuration::EnumConfigurationValue;
+pub use crate::context::call_reply::{CallReply, CallResult};
 pub use crate::context::keys_cursor::KeysCursor;
 pub use crate::context::server_events;
 pub use crate::context::thread_safe::RedisGILGuard;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,13 +27,14 @@ pub use crate::context::thread_safe::{DetachedFromClient, ThreadSafeContext};
 #[cfg(feature = "experimental-api")]
 pub use crate::raw::NotifyEvent;
 
-pub use crate::context::call_reply::{CallReply, InnerCallReply, RootCallReply};
+pub use crate::context::call_reply::{CallReply};
 pub use crate::context::keys_cursor::KeysCursor;
 pub use crate::context::server_events;
 pub use crate::context::thread_safe::RedisGILGuard;
 pub use crate::context::AclPermissions;
 pub use crate::context::CallOptions;
 pub use crate::context::CallOptionsBuilder;
+pub use crate::context::CallOptionResp;
 pub use crate::context::Context;
 pub use crate::context::ContextFlags;
 pub use crate::raw::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,14 +27,14 @@ pub use crate::context::thread_safe::{DetachedFromClient, ThreadSafeContext};
 #[cfg(feature = "experimental-api")]
 pub use crate::raw::NotifyEvent;
 
-pub use crate::context::call_reply::{CallReply};
+pub use crate::context::call_reply::CallReply;
 pub use crate::context::keys_cursor::KeysCursor;
 pub use crate::context::server_events;
 pub use crate::context::thread_safe::RedisGILGuard;
 pub use crate::context::AclPermissions;
+pub use crate::context::CallOptionResp;
 pub use crate::context::CallOptions;
 pub use crate::context::CallOptionsBuilder;
-pub use crate::context::CallOptionResp;
 pub use crate::context::Context;
 pub use crate::context::ContextFlags;
 pub use crate::raw::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@ pub use crate::context::thread_safe::{DetachedFromClient, ThreadSafeContext};
 #[cfg(feature = "experimental-api")]
 pub use crate::raw::NotifyEvent;
 
-pub use crate::context::call_reply::CallReply;
+pub use crate::context::call_reply::{CallReply, CallResult};
 pub use crate::context::keys_cursor::KeysCursor;
 pub use crate::context::server_events;
 pub use crate::context::thread_safe::RedisGILGuard;

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -15,6 +15,7 @@ pub(crate) fn log_internal(ctx: *mut raw::RedisModuleCtx, level: LogLevel, messa
 ///
 /// This function should be used when a callback is returning a critical error
 /// to the caller since cannot load or save the data for some critical reason.
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
 pub fn log_io_error(io: *mut raw::RedisModuleIO, level: LogLevel, message: &str) {
     if cfg!(feature = "test") {
         return;

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -255,8 +255,12 @@ pub fn reply_with_array(ctx: *mut RedisModuleCtx, len: c_long) -> Status {
 #[inline]
 pub fn reply_with_map(ctx: *mut RedisModuleCtx, len: c_long) -> Status {
     unsafe {
-        let cmd = RedisModule_ReplyWithMap.unwrap_or(RedisModule_ReplyWithArray.unwrap());
-        cmd(ctx, len).into()
+        RedisModule_ReplyWithMap
+            .map_or_else(
+                || RedisModule_ReplyWithArray.unwrap()(ctx, len * 2),
+                |f| f(ctx, len),
+            )
+            .into()
     }
 }
 
@@ -264,8 +268,12 @@ pub fn reply_with_map(ctx: *mut RedisModuleCtx, len: c_long) -> Status {
 #[inline]
 pub fn reply_with_set(ctx: *mut RedisModuleCtx, len: c_long) -> Status {
     unsafe {
-        let cmd = RedisModule_ReplyWithSet.unwrap_or(RedisModule_ReplyWithArray.unwrap());
-        cmd(ctx, len).into()
+        RedisModule_ReplyWithSet
+            .map_or_else(
+                || RedisModule_ReplyWithArray.unwrap()(ctx, len * 2),
+                |f| f(ctx, len),
+            )
+            .into()
     }
 }
 

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -230,11 +230,13 @@ pub fn call_reply_string(reply: *mut RedisModuleCallReply) -> String {
 }
 
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
+#[inline]
 pub fn close_key(kp: *mut RedisModuleKey) {
     unsafe { RedisModule_CloseKey.unwrap()(kp) }
 }
 
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
+#[inline]
 pub fn open_key(
     ctx: *mut RedisModuleCtx,
     keyname: *mut RedisModuleString,
@@ -244,8 +246,27 @@ pub fn open_key(
 }
 
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
+#[inline]
 pub fn reply_with_array(ctx: *mut RedisModuleCtx, len: c_long) -> Status {
     unsafe { RedisModule_ReplyWithArray.unwrap()(ctx, len).into() }
+}
+
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
+#[inline]
+pub fn reply_with_map(ctx: *mut RedisModuleCtx, len: c_long) -> Status {
+    unsafe { RedisModule_ReplyWithMap.unwrap()(ctx, len).into() }
+}
+
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
+#[inline]
+pub fn reply_with_set(ctx: *mut RedisModuleCtx, len: c_long) -> Status {
+    unsafe { RedisModule_ReplyWithSet.unwrap()(ctx, len).into() }
+}
+
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
+#[inline]
+pub fn reply_with_attribute(ctx: *mut RedisModuleCtx, len: c_long) -> Status {
+    unsafe { RedisModule_ReplyWithAttribute.unwrap()(ctx, len).into() }
 }
 
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
@@ -257,34 +278,64 @@ pub fn reply_with_error(ctx: *mut RedisModuleCtx, err: *const c_char) {
 }
 
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
+#[inline]
+pub fn reply_with_null(ctx: *mut RedisModuleCtx) -> Status {
+    unsafe { RedisModule_ReplyWithNull.unwrap()(ctx).into() }
+}
+
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
+#[inline]
+pub fn reply_with_bool(ctx: *mut RedisModuleCtx, b: c_int) -> Status {
+    unsafe { RedisModule_ReplyWithBool.unwrap()(ctx, b).into() }
+}
+
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
+#[inline]
 pub fn reply_with_long_long(ctx: *mut RedisModuleCtx, ll: c_longlong) -> Status {
     unsafe { RedisModule_ReplyWithLongLong.unwrap()(ctx, ll).into() }
 }
 
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
+#[inline]
 pub fn reply_with_double(ctx: *mut RedisModuleCtx, f: c_double) -> Status {
     unsafe { RedisModule_ReplyWithDouble.unwrap()(ctx, f).into() }
 }
 
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
+#[inline]
 pub fn reply_with_string(ctx: *mut RedisModuleCtx, s: *mut RedisModuleString) -> Status {
     unsafe { RedisModule_ReplyWithString.unwrap()(ctx, s).into() }
+}
+
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
+#[inline]
+pub fn reply_with_simple_string(ctx: *mut RedisModuleCtx, s: *const c_char) -> Status {
+    unsafe { RedisModule_ReplyWithSimpleString.unwrap()(ctx, s).into() }
+}
+
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
+#[inline]
+pub fn reply_with_string_buffer(ctx: *mut RedisModuleCtx, s: *const c_char, len: size_t) -> Status {
+    unsafe { RedisModule_ReplyWithStringBuffer.unwrap()(ctx, s, len).into() }
 }
 
 // Sets the expiry on a key.
 //
 // Expire is in milliseconds.
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
+#[inline]
 pub fn set_expire(key: *mut RedisModuleKey, expire: c_longlong) -> Status {
     unsafe { RedisModule_SetExpire.unwrap()(key, expire).into() }
 }
 
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
+#[inline]
 pub fn string_dma(key: *mut RedisModuleKey, len: *mut size_t, mode: KeyMode) -> *mut c_char {
     unsafe { RedisModule_StringDMA.unwrap()(key, len, mode.bits) }
 }
 
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
+#[inline]
 pub fn string_truncate(key: *mut RedisModuleKey, new_len: size_t) -> Status {
     unsafe { RedisModule_StringTruncate.unwrap()(key, new_len).into() }
 }
@@ -375,6 +426,7 @@ where
 }
 
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
+#[inline]
 pub fn hash_set(key: *mut RedisModuleKey, field: &str, value: *mut RedisModuleString) -> Status {
     let field = CString::new(field).unwrap();
 
@@ -391,6 +443,7 @@ pub fn hash_set(key: *mut RedisModuleKey, field: &str, value: *mut RedisModuleSt
 }
 
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
+#[inline]
 pub fn hash_del(key: *mut RedisModuleKey, field: &str) -> Status {
     let field = CString::new(field).unwrap();
 
@@ -411,6 +464,7 @@ pub fn hash_del(key: *mut RedisModuleKey, field: &str) -> Status {
 }
 
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
+#[inline]
 pub fn list_push(
     key: *mut RedisModuleKey,
     list_where: Where,
@@ -420,37 +474,44 @@ pub fn list_push(
 }
 
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
+#[inline]
 pub fn list_pop(key: *mut RedisModuleKey, list_where: Where) -> *mut RedisModuleString {
     unsafe { RedisModule_ListPop.unwrap()(key, list_where as i32) }
 }
 
 // Returns pointer to the C string, and sets len to its length
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
+#[inline]
 pub fn string_ptr_len(s: *const RedisModuleString, len: *mut size_t) -> *const c_char {
     unsafe { RedisModule_StringPtrLen.unwrap()(s, len) }
 }
 
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
+#[inline]
 pub fn string_retain_string(ctx: *mut RedisModuleCtx, s: *mut RedisModuleString) {
     unsafe { RedisModule_RetainString.unwrap()(ctx, s) }
 }
 
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
+#[inline]
 pub fn string_to_longlong(s: *const RedisModuleString, len: *mut i64) -> Status {
     unsafe { RedisModule_StringToLongLong.unwrap()(s, len).into() }
 }
 
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
+#[inline]
 pub fn string_to_double(s: *const RedisModuleString, len: *mut f64) -> Status {
     unsafe { RedisModule_StringToDouble.unwrap()(s, len).into() }
 }
 
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
+#[inline]
 pub fn string_set(key: *mut RedisModuleKey, s: *mut RedisModuleString) -> Status {
     unsafe { RedisModule_StringSet.unwrap()(key, s).into() }
 }
 
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
+#[inline]
 pub fn replicate_verbatim(ctx: *mut RedisModuleCtx) -> Status {
     unsafe { RedisModule_ReplicateVerbatim.unwrap()(ctx).into() }
 }

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -208,16 +208,25 @@ pub fn call_reply_integer(reply: *mut RedisModuleCallReply) -> c_longlong {
     unsafe { RedisModule_CallReplyInteger.unwrap()(reply) }
 }
 
+/// # Panics
+///
+/// Panics if the Redis server doesn't support replying with bool (since RESP3).
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
 pub fn call_reply_bool(reply: *mut RedisModuleCallReply) -> bool {
     (unsafe { RedisModule_CallReplyBool.unwrap()(reply) } != 0)
 }
 
+/// # Panics
+///
+/// Panics if the Redis server doesn't support replying with bool (since RESP3).
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
 pub fn call_reply_double(reply: *mut RedisModuleCallReply) -> f64 {
     unsafe { RedisModule_CallReplyDouble.unwrap()(reply) }
 }
 
+/// # Panics
+///
+/// Panics if the Redis server doesn't support replying with bool (since RESP3).
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
 pub fn call_reply_big_number(reply: *mut RedisModuleCallReply) -> Option<String> {
     unsafe {
@@ -231,6 +240,9 @@ pub fn call_reply_big_number(reply: *mut RedisModuleCallReply) -> Option<String>
     }
 }
 
+/// # Panics
+///
+/// Panics if the Redis server doesn't support replying with bool (since RESP3).
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
 pub fn call_reply_verbatim_string(reply: *mut RedisModuleCallReply) -> Option<(String, Vec<u8>)> {
     unsafe {
@@ -257,6 +269,9 @@ pub fn call_reply_array_element(
     unsafe { RedisModule_CallReplyArrayElement.unwrap()(reply, idx) }
 }
 
+/// # Panics
+///
+/// Panics if the Redis server doesn't support replying with bool (since RESP3).
 pub fn call_reply_set_element(
     reply: *mut RedisModuleCallReply,
     idx: usize,
@@ -264,6 +279,9 @@ pub fn call_reply_set_element(
     unsafe { RedisModule_CallReplySetElement.unwrap()(reply, idx) }
 }
 
+/// # Panics
+///
+/// Panics if the Redis server doesn't support replying with bool (since RESP3).
 pub fn call_reply_map_element(
     reply: *mut RedisModuleCallReply,
     idx: usize,

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -409,7 +409,11 @@ pub fn reply_with_big_number(ctx: *mut RedisModuleCtx, s: *const c_char, len: si
 
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
 #[inline]
-pub fn reply_with_verbatim_string(ctx: *mut RedisModuleCtx, s: *const c_char, len: size_t) -> Status {
+pub fn reply_with_verbatim_string(
+    ctx: *mut RedisModuleCtx,
+    s: *const c_char,
+    len: size_t,
+) -> Status {
     unsafe { RedisModule_ReplyWithVerbatimString.unwrap()(ctx, s, len).into() }
 }
 

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -254,13 +254,19 @@ pub fn reply_with_array(ctx: *mut RedisModuleCtx, len: c_long) -> Status {
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
 #[inline]
 pub fn reply_with_map(ctx: *mut RedisModuleCtx, len: c_long) -> Status {
-    unsafe { RedisModule_ReplyWithMap.unwrap()(ctx, len).into() }
+    unsafe {
+        let cmd = RedisModule_ReplyWithMap.unwrap_or(RedisModule_ReplyWithArray.unwrap());
+        cmd(ctx, len).into()
+    }
 }
 
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
 #[inline]
 pub fn reply_with_set(ctx: *mut RedisModuleCtx, len: c_long) -> Status {
-    unsafe { RedisModule_ReplyWithSet.unwrap()(ctx, len).into() }
+    unsafe {
+        let cmd = RedisModule_ReplyWithSet.unwrap_or(RedisModule_ReplyWithArray.unwrap());
+        cmd(ctx, len).into()
+    }
 }
 
 #[allow(clippy::not_unsafe_ptr_arg_deref)]

--- a/src/rediserror.rs
+++ b/src/rediserror.rs
@@ -1,3 +1,4 @@
+use crate::context::call_reply::ErrorCallReply;
 pub use crate::raw;
 use std::ffi::CStr;
 use std::fmt;
@@ -8,6 +9,15 @@ pub enum RedisError {
     Str(&'static str),
     String(String),
     WrongType,
+}
+
+impl<'root> From<ErrorCallReply<'root>> for RedisError {
+    fn from(err: ErrorCallReply<'root>) -> Self {
+        RedisError::String(
+            err.to_string()
+                .unwrap_or("can not convert error into String".into()),
+        )
+    }
 }
 
 impl RedisError {

--- a/src/redismodule.rs
+++ b/src/redismodule.rs
@@ -10,7 +10,7 @@ use std::str;
 use std::str::Utf8Error;
 use std::string::FromUtf8Error;
 
-use crate::context::call_reply::{CallReply};
+use crate::context::call_reply::CallReply;
 pub use crate::raw;
 pub use crate::rediserror::RedisError;
 pub use crate::redisvalue::RedisValue;

--- a/src/redismodule.rs
+++ b/src/redismodule.rs
@@ -274,6 +274,12 @@ impl From<RedisString> for String {
     }
 }
 
+impl From<RedisString> for Vec<u8> {
+    fn from(rs: RedisString) -> Self {
+        rs.as_slice().to_vec()
+    }
+}
+
 ///////////////////////////////////////////////////
 
 #[derive(Debug)]

--- a/src/redismodule.rs
+++ b/src/redismodule.rs
@@ -10,26 +10,15 @@ use std::str;
 use std::str::Utf8Error;
 use std::string::FromUtf8Error;
 
-use crate::context::call_reply::{InnerCallReply, RootCallReply};
+use crate::context::call_reply::{CallReply};
 pub use crate::raw;
 pub use crate::rediserror::RedisError;
 pub use crate::redisvalue::RedisValue;
 
 pub type RedisResult = Result<RedisValue, RedisError>;
 
-impl From<RootCallReply> for RedisResult {
-    fn from(reply: RootCallReply) -> Self {
-        let redis_value: RedisValue = (&reply).into();
-        match redis_value {
-            RedisValue::Error(s) => Err(RedisError::String(s)),
-            RedisValue::StaticError(s) => Err(RedisError::Str(s)),
-            _ => Ok(redis_value),
-        }
-    }
-}
-
-impl<'root> From<InnerCallReply<'root>> for RedisResult {
-    fn from(reply: InnerCallReply) -> Self {
+impl<'root> From<CallReply<'root>> for RedisResult {
+    fn from(reply: CallReply) -> Self {
         let redis_value: RedisValue = (&reply).into();
         match redis_value {
             RedisValue::Error(s) => Err(RedisError::String(s)),

--- a/src/redismodule.rs
+++ b/src/redismodule.rs
@@ -10,23 +10,11 @@ use std::str;
 use std::str::Utf8Error;
 use std::string::FromUtf8Error;
 
-use crate::context::call_reply::CallReply;
 pub use crate::raw;
 pub use crate::rediserror::RedisError;
 pub use crate::redisvalue::RedisValue;
 
 pub type RedisResult = Result<RedisValue, RedisError>;
-
-impl<'root> From<CallReply<'root>> for RedisResult {
-    fn from(reply: CallReply) -> Self {
-        let redis_value: RedisValue = (&reply).into();
-        match redis_value {
-            RedisValue::Error(s) => Err(RedisError::String(s)),
-            RedisValue::StaticError(s) => Err(RedisError::Str(s)),
-            _ => Ok(redis_value),
-        }
-    }
-}
 
 pub const REDIS_OK: RedisResult = Ok(RedisValue::SimpleStringStatic("OK"));
 pub const TYPE_METHOD_VERSION: u64 = raw::REDISMODULE_TYPE_METHOD_VERSION as u64;

--- a/src/redismodule.rs
+++ b/src/redismodule.rs
@@ -16,6 +16,18 @@ pub use crate::redisvalue::RedisValue;
 
 pub type RedisResult = Result<RedisValue, RedisError>;
 
+impl From<RedisValue> for RedisResult {
+    fn from(v: RedisValue) -> Self {
+        Ok(v)
+    }
+}
+
+impl From<RedisError> for RedisResult {
+    fn from(v: RedisError) -> Self {
+        Err(v)
+    }
+}
+
 pub const REDIS_OK: RedisResult = Ok(RedisValue::SimpleStringStatic("OK"));
 pub const TYPE_METHOD_VERSION: u64 = raw::REDISMODULE_TYPE_METHOD_VERSION as u64;
 

--- a/src/redisvalue.rs
+++ b/src/redisvalue.rs
@@ -24,6 +24,7 @@ pub enum RedisValue {
 
 impl Eq for RedisValue {}
 
+#[allow(clippy::derive_hash_xor_eq)]
 impl Hash for RedisValue {
     fn hash<H: Hasher>(&self, state: &mut H) {
         match self {

--- a/src/redisvalue.rs
+++ b/src/redisvalue.rs
@@ -57,7 +57,7 @@ impl Hash for RedisValue {
             RedisValue::VerbatimString((format, data)) => {
                 format.hash(state);
                 data.hash(state);
-            },
+            }
             RedisValue::Null => 0.hash(state),
             RedisValue::NoReply => 0.hash(state),
         }
@@ -155,23 +155,25 @@ impl<'root> From<&CallReply<'root>> for RedisValue {
         match reply {
             CallReply::Error(reply) => RedisValue::Error(reply.to_string().unwrap()),
             CallReply::Unknown => RedisValue::StaticError("Error on method call"),
-            CallReply::Array(reply) => RedisValue::Array(reply.iter().map(|v| (&v).into()).collect()),
+            CallReply::Array(reply) => {
+                RedisValue::Array(reply.iter().map(|v| (&v).into()).collect())
+            }
             CallReply::I64(reply) => RedisValue::Integer(reply.to_i64()),
             CallReply::String(reply) => RedisValue::SimpleString(reply.to_string().unwrap()),
             CallReply::Null(_) => RedisValue::Null,
-            CallReply::Map(reply) => RedisValue::Map(
-                reply
-                    .iter()
-                    .fold(HashMap::new(), |mut acc, (key, val)| {
-                        acc.insert((&key).into(), (&val).into());
-                        acc
-                    })
-            ),
+            CallReply::Map(reply) => {
+                RedisValue::Map(reply.iter().fold(HashMap::new(), |mut acc, (key, val)| {
+                    acc.insert((&key).into(), (&val).into());
+                    acc
+                }))
+            }
             CallReply::Set(reply) => RedisValue::Set(reply.iter().map(|v| (&v).into()).collect()),
             CallReply::Bool(reply) => RedisValue::Bool(reply.to_bool()),
             CallReply::Double(reply) => RedisValue::Float(reply.to_double()),
             CallReply::BigNumber(reply) => RedisValue::BigNumber(reply.to_string().unwrap()),
-            CallReply::VerbatimString(reply) => RedisValue::VerbatimString(reply.to_parts().unwrap())
+            CallReply::VerbatimString(reply) => {
+                RedisValue::VerbatimString(reply.to_parts().unwrap())
+            }
         }
     }
 }

--- a/src/redisvalue.rs
+++ b/src/redisvalue.rs
@@ -4,7 +4,7 @@ use std::{
     hash::Hash,
 };
 
-#[derive(Debug, PartialEq, Eq, Hash)]
+#[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub enum RedisValueKey {
     Integer(i64),
     String(String),
@@ -13,7 +13,7 @@ pub enum RedisValueKey {
     Bool(bool),
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum RedisValue {
     SimpleStringStatic(&'static str),
     SimpleString(String),

--- a/src/redisvalue.rs
+++ b/src/redisvalue.rs
@@ -1,8 +1,17 @@
 use crate::{context::call_reply::CallResult, CallReply, RedisError, RedisString};
 use std::{
     collections::{HashMap, HashSet},
-    hash::{Hash, Hasher},
+    hash::Hash,
 };
+
+#[derive(Debug, PartialEq, Eq, Hash)]
+pub enum RedisValueKey {
+    Integer(i64),
+    String(String),
+    BulkRedisString(RedisString),
+    BulkString(Vec<u8>),
+    Bool(bool),
+}
 
 #[derive(Debug, PartialEq)]
 pub enum RedisValue {
@@ -18,48 +27,10 @@ pub enum RedisValue {
     VerbatimString((String, Vec<u8>)),
     Array(Vec<RedisValue>),
     StaticError(&'static str),
-    Map(HashMap<RedisValue, RedisValue>),
-    Set(HashSet<RedisValue>),
+    Map(HashMap<RedisValueKey, RedisValue>),
+    Set(HashSet<RedisValueKey>),
     Null,
     NoReply, // No reply at all (as opposed to a Null reply)
-}
-
-impl Eq for RedisValue {}
-
-#[allow(clippy::derive_hash_xor_eq)]
-impl Hash for RedisValue {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        match self {
-            RedisValue::SimpleStringStatic(s) => s.hash(state),
-            RedisValue::SimpleString(s) => s.hash(state),
-            RedisValue::BulkString(s) => s.hash(state),
-            RedisValue::BulkRedisString(s) => s.hash(state),
-            RedisValue::StringBuffer(s) => s.hash(state),
-            RedisValue::Integer(i) => i.hash(state),
-            RedisValue::Bool(b) => b.hash(state),
-            RedisValue::Float(f) => f.to_bits().hash(state),
-            RedisValue::Array(a) => a.hash(state),
-            RedisValue::StaticError(a) => a.hash(state),
-            RedisValue::Map(m) => {
-                for (k, v) in m {
-                    k.hash(state);
-                    v.hash(state);
-                }
-            }
-            RedisValue::Set(s) => {
-                for v in s {
-                    v.hash(state);
-                }
-            }
-            RedisValue::BigNumber(a) => a.hash(state),
-            RedisValue::VerbatimString((format, data)) => {
-                format.hash(state);
-                data.hash(state);
-            }
-            RedisValue::Null => 0.hash(state),
-            RedisValue::NoReply => 0.hash(state),
-        }
-    }
 }
 
 impl TryFrom<RedisValue> for String {
@@ -148,6 +119,25 @@ impl<T: Into<Self>> From<Vec<T>> for RedisValue {
     }
 }
 
+impl<'root> TryFrom<&CallReply<'root>> for RedisValueKey {
+    type Error = RedisError;
+    fn try_from(reply: &CallReply<'root>) -> Result<Self, Self::Error> {
+        match reply {
+            CallReply::I64(reply) => Ok(RedisValueKey::Integer(reply.to_i64())),
+            CallReply::String(reply) => Ok(reply
+                .to_string()
+                .map_or(RedisValueKey::BulkString(reply.as_bytes().to_vec()), |v| {
+                    RedisValueKey::String(v)
+                })),
+            CallReply::Bool(b) => Ok(RedisValueKey::Bool(b.to_bool())),
+            _ => Err(RedisError::String(format!(
+                "Given CallReply can not be used as a map key or a set element, {:?}",
+                reply
+            ))),
+        }
+    }
+}
+
 impl<'root> From<&CallReply<'root>> for RedisValue {
     fn from(reply: &CallReply<'root>) -> Self {
         match reply {
@@ -161,10 +151,25 @@ impl<'root> From<&CallReply<'root>> for RedisValue {
             CallReply::Map(reply) => RedisValue::Map(
                 reply
                     .iter()
-                    .map(|(key, val)| ((&key).into(), (&val).into()))
+                    .map(|(key, val)| {
+                        (
+                            (&key)
+                                .try_into()
+                                .expect(&format!("Got unhashable map key from Redis, {:?}", key)),
+                            (&val).into(),
+                        )
+                    })
                     .collect(),
             ),
-            CallReply::Set(reply) => RedisValue::Set(reply.iter().map(|v| (&v).into()).collect()),
+            CallReply::Set(reply) => RedisValue::Set(
+                reply
+                    .iter()
+                    .map(|v| {
+                        (&v).try_into()
+                            .expect(&format!("Got unhashable set element from Redis, {:?}", v))
+                    })
+                    .collect(),
+            ),
             CallReply::Bool(reply) => RedisValue::Bool(reply.to_bool()),
             CallReply::Double(reply) => RedisValue::Float(reply.to_double()),
             CallReply::BigNumber(reply) => RedisValue::BigNumber(reply.to_string().unwrap()),
@@ -185,6 +190,20 @@ impl<'root> From<&CallResult<'root>> for RedisValue {
                 RedisValue::SimpleString(e.to_string().unwrap())
             },
             |v| (v).into(),
+        )
+    }
+}
+
+impl<'root> TryFrom<&CallResult<'root>> for RedisValueKey {
+    type Error = RedisError;
+    fn try_from(reply: &CallResult<'root>) -> Result<Self, Self::Error> {
+        reply.as_ref().map_or_else(
+            |e| {
+                Err(RedisError::String(
+                    format!("Got an error reply which can not be translated into a map key or set element, {:?}", e),
+                ))
+            },
+            |v| v.try_into(),
         )
     }
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -265,18 +265,20 @@ fn test_response() -> Result<()> {
         .query(&mut con)
         .with_context(|| "failed to run string.set")?;
 
-    let res: Vec<String> = redis::cmd("map.mget")
+    let mut res: Vec<String> = redis::cmd("map.mget")
         .arg(&["k", "a", "c", "e"])
         .query(&mut con)
         .with_context(|| "failed to run string.set")?;
 
-    assert_eq!(&res, &["a", "b", "c", "d", "e", "b"]);
+    res.sort();
+    assert_eq!(&res, &["a", "b", "b", "c", "d", "e"]);
 
-    let res: Vec<String> = redis::cmd("map.unique")
+    let mut res: Vec<String> = redis::cmd("map.unique")
         .arg(&["k", "a", "c", "e"])
         .query(&mut con)
         .with_context(|| "failed to run string.set")?;
 
+    res.sort();
     assert_eq!(&res, &["b", "d"]);
 
     Ok(())

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -254,7 +254,7 @@ fn test_call() -> Result<()> {
 
 #[test]
 fn test_response() -> Result<()> {
-    let port: u16 = 6488;
+    let port: u16 = 6489;
     let _guards = vec![start_redis_server_with_module("response", port)
         .with_context(|| "failed to start redis server")?];
     let mut con =


### PR DESCRIPTION
The PR adds Resp3 support for both, return result from module command and getting result as resp3 on `ctx.call_ext` (when resp3 option is used).

Tests was added to verify both new functionalities.

The PR also refactor the `CallReply` API introduced on https://github.com/RedisLabsModules/redismodule-rs/pull/290. Instead of having 2 types of `CallReply` we now have one type such that the root call reply created with `'static` lifetime indicating that the user can hold it for as long as it want. Internal `CallReply` can outlive its father.
As part of the refactoring, the `CallReply` was changed to be more rust friendly. `CallReply` was renamed to `CallResult = Result<CallReply, ErrorCallReply>`, `CallReply` is an enum which allows to check the `CallReply` type using a `match` statement.