### PR TITLE
Fix invalid use of the crate keyword in macro_rules.

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -201,9 +201,9 @@ macro_rules! redis_module {
 
             $(
                 $(
-                    if let Err(err) = (crate::redis_module::context::server_events::subscribe_to_server_event(
+                    if let Err(err) = ($crate::context::server_events::subscribe_to_server_event(
                         &context,
-                        crate::redis_module::context::server_events::ServerEvents::$server_event_type,
+                        $crate::context::server_events::ServerEvents::$server_event_type,
                         Box::new($server_event_handler))) {
                             context.log_warning(&format!("Failed register server event, {}", err));
                             return $crate::Status::Err as c_int;


### PR DESCRIPTION
Within the macro_rules! the $crate should be used when it is required to refer to the current crate.
This commit changes the referencing to the correct one.