### PR TITLE
Fix minor code issues.

### DIFF
--- a/examples/data_type.rs
+++ b/examples/data_type.rs
@@ -42,7 +42,7 @@ static MY_REDIS_TYPE: RedisType = RedisType::new(
 );
 
 unsafe extern "C" fn free(value: *mut c_void) {
-    Box::from_raw(value.cast::<MyType>());
+    drop(Box::from_raw(value.cast::<MyType>()));
 }
 
 fn alloc_set(ctx: &Context, args: Vec<RedisString>) -> RedisResult {

--- a/src/context/configuration.rs
+++ b/src/context/configuration.rs
@@ -15,12 +15,12 @@ impl ConfigFlags {
         }
     }
 
-    pub fn emmutable(mut self) -> Self {
+    pub fn immutable(mut self) -> Self {
         self.flags |= raw::REDISMODULE_CONFIG_IMMUTABLE;
         self
     }
 
-    pub fn is_emmutable(&self) -> bool {
+    pub fn is_immutable(&self) -> bool {
         self.flags & raw::REDISMODULE_CONFIG_IMMUTABLE != 0
     }
 


### PR DESCRIPTION
1. Fixes the warning of the unused result. Now the result is explicitly dropped and so the intention behind the code written is clear.
2. Fixes the typo - "emmutable" to "immutable".