### PR TITLE
Allow for easier version compatibility checking.

### DIFF
--- a/src/raw.rs
+++ b/src/raw.rs
@@ -721,7 +721,7 @@ pub fn get_keyspace_events() -> NotifyEvent {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Version {
     pub major: i32,
     pub minor: i32,


### PR DESCRIPTION
By deriving Ord and PartialOrd we can compare two versions easier. We need to be able to compare the versions to make sure the compatible version is used with the module.