### PR TITLE
Adde API for ACL validation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,10 @@ name = "string"
 crate-type = ["cdylib"]
 
 [[example]]
+name = "acl"
+crate-type = ["cdylib"]
+
+[[example]]
 name = "call"
 crate-type = ["cdylib"]
 

--- a/examples/acl.rs
+++ b/examples/acl.rs
@@ -1,0 +1,31 @@
+#[macro_use]
+extern crate redis_module;
+
+use redis_module::{Context, RedisResult, RedisError, RedisString, RedisValue, NextArg, AclPermissions};
+
+fn verify_key_access_for_user(ctx: &Context, args: Vec<RedisString>) -> RedisResult {
+    let mut args = args.into_iter().skip(1);
+    let user = args.next_arg()?;
+    let key = args.next_arg()?;
+    let res = ctx.acl_check_key_permission(&user, &key, &AclPermissions::all());
+    if let Err(err) = res {
+        return Err(RedisError::String(format!("Err {err}")));
+    }
+    Ok(RedisValue::SimpleStringStatic("OK"))
+}
+
+fn get_current_user(ctx: &Context, _args: Vec<RedisString>) -> RedisResult {
+    Ok(RedisValue::BulkRedisString(ctx.get_current_user()))
+}
+
+//////////////////////////////////////////////////////
+
+redis_module! {
+    name: "acl",
+    version: 1,
+    data_types: [],
+    commands: [
+        ["verify_key_access_for_user", verify_key_access_for_user, "", 0, 0, 0],
+        ["get_current_user", get_current_user, "", 0, 0, 0],
+    ],
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,7 @@ pub use crate::raw::NotifyEvent;
 pub use crate::context::keys_cursor::KeysCursor;
 pub use crate::context::Context;
 pub use crate::context::ContextFlags;
+pub use crate::context::AclPermissions;
 pub use crate::raw::*;
 pub use crate::redismodule::*;
 use backtrace::Backtrace;


### PR DESCRIPTION
The PR adds 3 API's for ACL validations:

1. Get current user from the Redis context (as `RedisString`).
2. Authenicate the context on a given user.
3. Check if a key has a given permission on a given user.

Relevant tests was added to verify the new functionality.