### PR TITLE
Added context mutex struct that allows to save static data protected by Redis GIL

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,13 +94,14 @@ backtrace = "0.3"
 [dev-dependencies]
 anyhow = "1.0.38"
 redis = "0.22.1"
+lazy_static = "1.4.0"
 
 [build-dependencies]
 bindgen = "0.64"
 cc = "1.0"
 
 [features]
-default = []
+default = ["experimental-api"]
 experimental-api = []
 
 # Workaround to allow cfg(feature = "test") in dependencies:

--- a/examples/threads.rs
+++ b/examples/threads.rs
@@ -1,7 +1,10 @@
 #[macro_use]
 extern crate redis_module;
 
-use redis_module::{Context, RedisResult, RedisString, ThreadSafeContext};
+use lazy_static::lazy_static;
+use redis_module::{
+    Context, ContextMutex, NextArg, RedisResult, RedisString, RedisValue, ThreadSafeContext,
+};
 use std::mem::drop;
 use std::thread;
 use std::time::Duration;
@@ -22,6 +25,40 @@ fn threads(_: &Context, _args: Vec<RedisString>) -> RedisResult {
     Ok(().into())
 }
 
+#[derive(Default)]
+struct StaticData {
+    data: String,
+}
+
+lazy_static! {
+    static ref STATIC_DATA: ContextMutex<StaticData> = ContextMutex::default();
+}
+
+fn set_static_data(ctx: &Context, args: Vec<RedisString>) -> RedisResult {
+    let mut args = args.into_iter().skip(1);
+    let val = args.next_str()?;
+    let mut static_data = STATIC_DATA.lock(ctx);
+    static_data.data = val.to_string();
+    Ok(RedisValue::SimpleStringStatic("OK"))
+}
+
+fn get_static_data(ctx: &Context, _args: Vec<RedisString>) -> RedisResult {
+    let static_data = STATIC_DATA.lock(ctx);
+    Ok(RedisValue::BulkString(static_data.data.clone()))
+}
+
+fn get_static_data_on_thread(ctx: &Context, _args: Vec<RedisString>) -> RedisResult {
+    let blocked_client = ctx.block_client();
+    thread::spawn(move || {
+        let thread_ctx = ThreadSafeContext::with_blocked_client(blocked_client);
+        let ctx = thread_ctx.lock();
+        let static_data = STATIC_DATA.lock(&ctx);
+        thread_ctx.reply(Ok(static_data.data.clone().into()));
+    });
+
+    Ok(RedisValue::NoReply)
+}
+
 //////////////////////////////////////////////////////
 
 redis_module! {
@@ -30,5 +67,8 @@ redis_module! {
     data_types: [],
     commands: [
         ["threads", threads, "", 0, 0, 0],
+        ["set_static_data", set_static_data, "", 0, 0, 0],
+        ["get_static_data", get_static_data, "", 0, 0, 0],
+        ["get_static_data_on_thread", get_static_data_on_thread, "", 0, 0, 0],
     ],
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,7 @@ pub use crate::context::thread_safe::{DetachedFromClient, ThreadSafeContext};
 pub use crate::raw::NotifyEvent;
 
 pub use crate::context::keys_cursor::KeysCursor;
+pub use crate::context::thread_safe::ContextMutex;
 pub use crate::context::Context;
 pub use crate::context::ContextFlags;
 pub use crate::raw::*;

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -266,3 +266,25 @@ fn test_ctx_flags() -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn test_context_mutex() -> Result<()> {
+    let port: u16 = 6490;
+    let _guards = vec![start_redis_server_with_module("threads", port)
+        .with_context(|| "failed to start redis server")?];
+    let mut con =
+        get_redis_connection(port).with_context(|| "failed to connect to redis server")?;
+
+    let res: String = redis::cmd("set_static_data")
+        .arg(&["foo"])
+        .query(&mut con)?;
+    assert_eq!(&res, "OK");
+
+    let res: String = redis::cmd("get_static_data").query(&mut con)?;
+    assert_eq!(&res, "foo");
+
+    let res: String = redis::cmd("get_static_data_on_thread").query(&mut con)?;
+    assert_eq!(&res, "foo");
+
+    Ok(())
+}


### PR DESCRIPTION
There are a wide range of usecases that require the module to save static data. Most of the times this static data also need to be mutated by the module. Rust, by definition, defines mutable static data as unsafe and accessing it, even in a none mutable way, require unsafe code.

In order to avoid unsafe code, one must wrap the static data with a mutex. The issue is that most of the times the data is only accessed when the Redis GIL is held, wrapping the data with another mutex just to avoid unsafe code is redudent and can even reduce performance.

The PR introduce a `ContextMutex` struct that just like a regular mutex, can wrap data and make it safe to access the it. The `ContextMutex` can be locked by giving it a reference to a `RedisContext` and the lock period can not outlive the given RedisContext nor the `ContextMutex`.

`ContextMutex` can also safely pass between threads (implements `Sync` and `Send`). So it can also be used to pass objects to other threads and use them (after acquire the Redis GIL).

**Notice**: The base assumption is that when the code has a reference to `RedisContext` the Redis GIL must be acquired. This assumption is currently not always true. We should find locations where we break this assumption and fix it gradually.