### PR TITLE
Added configuration API.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,10 @@ name = "string"
 crate-type = ["cdylib"]
 
 [[example]]
+name = "configuration"
+crate-type = ["cdylib"]
+
+[[example]]
 name = "acl"
 crate-type = ["cdylib"]
 

--- a/examples/configuration.rs
+++ b/examples/configuration.rs
@@ -77,5 +77,6 @@ redis_module! {
             ["enum", &*CONFIGURATION_ENUM, EnumConfiguration::Val1, ConfigurationFlags::DEFAULT, Some(Box::new(on_configuration_changed))],
             ["enum_mutex", &*CONFIGURATION_MUTEX_ENUM, EnumConfiguration::Val1, ConfigurationFlags::DEFAULT, Some(Box::new(on_configuration_changed))],
         ],
+        module_args_as_configuration: true,
     ]
 }

--- a/examples/configuration.rs
+++ b/examples/configuration.rs
@@ -1,0 +1,59 @@
+#[macro_use]
+extern crate redis_module;
+
+use std::sync::{
+    atomic::{AtomicBool, AtomicI64},
+    Mutex,
+};
+
+use lazy_static::lazy_static;
+use redis_module::{
+    configuration::ConfigurationFlags, EnumConfigurationValue, RedisGILGuard, RedisString,
+};
+
+enum_configuration! {
+    enum EnumConfiguration {
+        Val1 = 1,
+        Val2 = 2,
+    }
+}
+
+lazy_static! {
+    static ref CONFIGURATION_I64: RedisGILGuard<i64> = RedisGILGuard::default();
+    static ref CONFIGURATION_ATOMIC_I64: AtomicI64 = AtomicI64::new(1);
+    static ref CONFIGURATION_REDIS_STRING: RedisGILGuard<RedisString> =
+        RedisGILGuard::new(RedisString::create(None, "default"));
+    static ref CONFIGURATION_STRING: RedisGILGuard<String> = RedisGILGuard::new("default".into());
+    static ref CONFIGURATION_MUTEX_STRING: Mutex<String> = Mutex::new("default".into());
+    static ref CONFIGURATION_ATOMIC_BOOL: AtomicBool = AtomicBool::default();
+    static ref CONFIGURATION_BOOL: RedisGILGuard<bool> = RedisGILGuard::default();
+    static ref CONFIGURATION_ENUM: RedisGILGuard<EnumConfiguration> =
+        RedisGILGuard::new(EnumConfiguration::Val1);
+}
+
+//////////////////////////////////////////////////////
+
+redis_module! {
+    name: "configuration",
+    version: 1,
+    data_types: [],
+    commands: [],
+    configurations: [
+        i64: [
+            ["i64", &*CONFIGURATION_I64, 10, 0, 1000, ConfigurationFlags::DEFAULT],
+            ["atomic_i64", &*CONFIGURATION_ATOMIC_I64, 10, 0, 1000, ConfigurationFlags::DEFAULT],
+        ],
+        string: [
+            ["redis_string", &*CONFIGURATION_REDIS_STRING, "default", ConfigurationFlags::DEFAULT],
+            ["string", &*CONFIGURATION_STRING, "default", ConfigurationFlags::DEFAULT],
+            ["mutex_string", &*CONFIGURATION_MUTEX_STRING, "default", ConfigurationFlags::DEFAULT],
+        ],
+        bool: [
+            ["atomic_bool", &*CONFIGURATION_ATOMIC_BOOL, true, ConfigurationFlags::DEFAULT],
+            ["bool", &*CONFIGURATION_BOOL, true, ConfigurationFlags::DEFAULT],
+        ],
+        enum: [
+            ["enum", &*CONFIGURATION_ENUM, EnumConfiguration::Val1, ConfigurationFlags::DEFAULT],
+        ],
+    ]
+}

--- a/examples/configuration.rs
+++ b/examples/configuration.rs
@@ -29,6 +29,8 @@ lazy_static! {
     static ref CONFIGURATION_BOOL: RedisGILGuard<bool> = RedisGILGuard::default();
     static ref CONFIGURATION_ENUM: RedisGILGuard<EnumConfiguration> =
         RedisGILGuard::new(EnumConfiguration::Val1);
+    static ref CONFIGURATION_MUTEX_ENUM: Mutex<EnumConfiguration> =
+        Mutex::new(EnumConfiguration::Val1);
 }
 
 //////////////////////////////////////////////////////
@@ -54,6 +56,7 @@ redis_module! {
         ],
         enum: [
             ["enum", &*CONFIGURATION_ENUM, EnumConfiguration::Val1, ConfigurationFlags::DEFAULT],
+            ["enum_mutex", &*CONFIGURATION_MUTEX_ENUM, EnumConfiguration::Val1, ConfigurationFlags::DEFAULT],
         ],
     ]
 }

--- a/examples/configuration.rs
+++ b/examples/configuration.rs
@@ -21,7 +21,7 @@ enum_configuration! {
 }
 
 lazy_static! {
-    static ref NUM_OF_CONFIGERATION_CHANGES: RedisGILGuard<i64> = RedisGILGuard::default();
+    static ref NUM_OF_CONFIGURATION_CHANGES: RedisGILGuard<i64> = RedisGILGuard::default();
     static ref CONFIGURATION_I64: RedisGILGuard<i64> = RedisGILGuard::default();
     static ref CONFIGURATION_ATOMIC_I64: AtomicI64 = AtomicI64::new(1);
     static ref CONFIGURATION_REDIS_STRING: RedisGILGuard<RedisString> =
@@ -41,12 +41,12 @@ fn on_configuration_changed<G, T: ConfigurationValue<G>>(
     _name: &str,
     _val: &'static T,
 ) {
-    let mut val = NUM_OF_CONFIGERATION_CHANGES.lock(config_ctx);
+    let mut val = NUM_OF_CONFIGURATION_CHANGES.lock(config_ctx);
     *val += 1
 }
 
 fn num_changes(ctx: &Context, _: Vec<RedisString>) -> RedisResult {
-    let val = NUM_OF_CONFIGERATION_CHANGES.lock(ctx);
+    let val = NUM_OF_CONFIGURATION_CHANGES.lock(ctx);
     Ok(RedisValue::Integer(*val))
 }
 

--- a/examples/events.rs
+++ b/examples/events.rs
@@ -4,6 +4,7 @@ extern crate redis_module;
 use redis_module::{
     Context, NotifyEvent, RedisError, RedisResult, RedisString, RedisValue, Status,
 };
+use std::ptr::NonNull;
 use std::sync::atomic::{AtomicI64, Ordering};
 
 static NUM_KEY_MISSES: AtomicI64 = AtomicI64::new(0);
@@ -25,7 +26,7 @@ fn event_send(ctx: &Context, args: Vec<RedisString>) -> RedisResult {
         return Err(RedisError::WrongArity);
     }
 
-    let key_name = RedisString::create(ctx.ctx, "mykey");
+    let key_name = RedisString::create(NonNull::new(ctx.ctx), "mykey");
     let status = ctx.notify_keyspace_event(NotifyEvent::GENERIC, "events.send", &key_name);
     match status {
         Status::Ok => Ok("Event sent".into()),

--- a/examples/threads.rs
+++ b/examples/threads.rs
@@ -1,7 +1,7 @@
 #[macro_use]
 extern crate redis_module;
 
-use lazy_static::lazy_static;
+use lazy_static::{lazy_static};
 use redis_module::{
     Context, NextArg, RedisGILGuard, RedisResult, RedisString, RedisValue, ThreadSafeContext,
 };

--- a/examples/threads.rs
+++ b/examples/threads.rs
@@ -31,7 +31,7 @@ struct StaticData {
 }
 
 lazy_static! {
-    static ref STATIC_DATA: RedisGILGuard<StaticData> = RedisGILGuard::default();
+    static ref STATIC_DATA: RedisGILGuard<StaticData> = RedisGILGuard::new(StaticData::default());
 }
 
 fn set_static_data(ctx: &Context, args: Vec<RedisString>) -> RedisResult {

--- a/examples/threads.rs
+++ b/examples/threads.rs
@@ -1,7 +1,7 @@
 #[macro_use]
 extern crate redis_module;
 
-use lazy_static::{lazy_static};
+use lazy_static::lazy_static;
 use redis_module::{
     Context, NextArg, RedisGILGuard, RedisResult, RedisString, RedisValue, ThreadSafeContext,
 };

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -6,6 +6,7 @@ use std::sync::atomic::{AtomicBool, AtomicI64, Ordering};
 use std::sync::Mutex;
 
 bitflags! {
+    /// Configuration options
     pub struct ConfigurationFlags : c_int {
         /// The default flags for a config. This creates a config that can be modified after startup.
         const DEFAULT = raw::REDISMODULE_CONFIG_DEFAULT as c_int;
@@ -92,6 +93,18 @@ impl<T: Clone> ConfigurationValue<T> for RedisGILGuard<T> {
     }
     fn set(&self, ctx: &Context, val: T) -> Result<(), RedisError> {
         let mut value = self.lock(ctx);
+        *value = val;
+        Ok(())
+    }
+}
+
+impl<T: Clone + Send> ConfigurationValue<T> for Mutex<T> {
+    fn get(&self, _ctx: &Context) -> T {
+        let value = self.lock().unwrap();
+        value.clone()
+    }
+    fn set(&self, _ctx: &Context, val: T) -> Result<(), RedisError> {
+        let mut value = self.lock().unwrap();
         *value = val;
         Ok(())
     }

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -424,3 +424,23 @@ pub fn register_enum_configuration<G: EnumConfigurationValue, T: ConfigurationVa
         );
     }
 }
+
+pub fn apply_module_args_as_configuration(
+    ctx: &Context,
+    mut args: Vec<RedisString>,
+) -> Result<(), RedisError> {
+    if args.len() == 0 {
+        return Ok(());
+    }
+    if args.len() % 2 != 0 {
+        return Err(RedisError::Str(
+            "Arguments lenght is not devided by 2 (require to be read as module configuration).",
+        ));
+    }
+    args.insert(0, ctx.create_string("set"));
+    ctx.call(
+        "config",
+        args.iter().collect::<Vec<&RedisString>>().as_slice(),
+    )?;
+    Ok(())
+}

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -1,0 +1,352 @@
+use crate::{raw, RedisGILGuard};
+use crate::{Context, RedisError, RedisString};
+use bitflags::bitflags;
+use std::ffi::{c_char, c_int, c_longlong, c_void, CString};
+use std::sync::atomic::{AtomicBool, AtomicI64, Ordering};
+use std::sync::Mutex;
+
+bitflags! {
+    pub struct ConfigurationFlags : c_int {
+        /// The default flags for a config. This creates a config that can be modified after startup.
+        const DEFAULT = raw::REDISMODULE_CONFIG_DEFAULT as c_int;
+
+        /// This config can only be provided loading time.
+        const IMMUTABLE = raw::REDISMODULE_CONFIG_IMMUTABLE as c_int;
+
+        /// The value stored in this config is redacted from all logging.
+        const SENSITIVE = raw::REDISMODULE_CONFIG_SENSITIVE as c_int;
+
+        /// The name is hidden from `CONFIG GET` with pattern matching.
+        const HIDDEN = raw::REDISMODULE_CONFIG_HIDDEN as c_int;
+
+        /// This config will be only be modifiable based off the value of enable-protected-configs.
+        const PROTECTED = raw::REDISMODULE_CONFIG_PROTECTED as c_int;
+
+        /// This config is not modifiable while the server is loading data.
+        const DENY_LOADING = raw::REDISMODULE_CONFIG_DENY_LOADING as c_int;
+
+        /// For numeric configs, this config will convert data unit notations into their byte equivalent.
+        const MEMORY = raw::REDISMODULE_CONFIG_MEMORY as c_int;
+
+        /// For enum configs, this config will allow multiple entries to be combined as bit flags.
+        const BITFLAGS = raw::REDISMODULE_CONFIG_BITFLAGS as c_int;
+    }
+}
+
+#[macro_export]
+macro_rules! enum_configuration {
+    ($(#[$meta:meta])* $vis:vis enum $name:ident {
+        $($(#[$vmeta:meta])* $vname:ident = $val:expr,)*
+    }) => {
+        $(#[$meta])*
+        $vis enum $name {
+            $($(#[$vmeta])* $vname = $val,)*
+        }
+
+        impl std::convert::TryFrom<i32> for $name {
+            type Error = $crate::RedisError;
+
+            fn try_from(v: i32) -> Result<Self, Self::Error> {
+                match v {
+                    $(x if x == $name::$vname as i32 => Ok($name::$vname),)*
+                    _ => Err($crate::RedisError::Str("Value is not supported")),
+                }
+            }
+        }
+
+        impl std::convert::From<$name> for i32 {
+            fn from(val: $name) -> Self {
+                val as i32
+            }
+        }
+
+        impl EnumConfigurationValue for $name {
+            fn get_options(&self) -> (Vec<String>, Vec<i32>) {
+                (vec![$(stringify!($vname).to_string(),)*], vec![$($val,)*])
+            }
+        }
+
+        impl Clone for $name {
+            fn clone(&self) -> Self {
+                match self {
+                    $($name::$vname => $name::$vname,)*
+                }
+            }
+        }
+    }
+}
+
+pub trait ConfigurationValue<T>: Sync + Send {
+    fn get(&self, ctx: &Context) -> T;
+    fn set(&self, ctx: &Context, val: T) -> Result<(), RedisError>;
+}
+
+pub trait EnumConfigurationValue: TryFrom<i32, Error = RedisError> + Into<i32> + Clone {
+    fn get_options(&self) -> (Vec<String>, Vec<i32>);
+}
+
+impl<T: Clone> ConfigurationValue<T> for RedisGILGuard<T> {
+    fn get(&self, ctx: &Context) -> T {
+        let value = self.lock(ctx);
+        value.clone()
+    }
+    fn set(&self, ctx: &Context, val: T) -> Result<(), RedisError> {
+        let mut value = self.lock(ctx);
+        *value = val;
+        Ok(())
+    }
+}
+
+impl ConfigurationValue<i64> for AtomicI64 {
+    fn get(&self, _ctx: &Context) -> i64 {
+        self.load(Ordering::Relaxed)
+    }
+    fn set(&self, _ctx: &Context, val: i64) -> Result<(), RedisError> {
+        self.store(val, Ordering::Relaxed);
+        Ok(())
+    }
+}
+
+impl ConfigurationValue<RedisString> for RedisGILGuard<String> {
+    fn get(&self, ctx: &Context) -> RedisString {
+        let value = self.lock(ctx);
+        RedisString::create(None, &value)
+    }
+    fn set(&self, ctx: &Context, val: RedisString) -> Result<(), RedisError> {
+        let mut value = self.lock(ctx);
+        *value = val.try_as_str()?.to_string();
+        Ok(())
+    }
+}
+
+impl ConfigurationValue<RedisString> for Mutex<String> {
+    fn get(&self, _ctx: &Context) -> RedisString {
+        let value = self.lock().unwrap();
+        RedisString::create(None, &value)
+    }
+    fn set(&self, _ctx: &Context, val: RedisString) -> Result<(), RedisError> {
+        let mut value = self.lock().unwrap();
+        *value = val.try_as_str()?.to_string();
+        Ok(())
+    }
+}
+
+impl ConfigurationValue<bool> for AtomicBool {
+    fn get(&self, _ctx: &Context) -> bool {
+        self.load(Ordering::Relaxed)
+    }
+    fn set(&self, _ctx: &Context, val: bool) -> Result<(), RedisError> {
+        self.store(val, Ordering::Relaxed);
+        Ok(())
+    }
+}
+
+extern "C" fn i64_configuration_set<T: ConfigurationValue<i64>>(
+    _name: *const c_char,
+    val: c_longlong,
+    privdata: *mut c_void,
+    err: *mut *mut raw::RedisModuleString,
+) -> c_int {
+    let variable = unsafe { &*(privdata as *const T) };
+    // we know the GIL is held so it is safe to use Context::dummy().
+    if let Err(e) = variable.set(&Context::dummy(), val) {
+        let error_msg = RedisString::create(None, &e.to_string());
+        unsafe { *err = error_msg.take() };
+        return raw::REDISMODULE_ERR as i32;
+    }
+    raw::REDISMODULE_OK as i32
+}
+
+extern "C" fn i64_configuration_get<T: ConfigurationValue<i64>>(
+    _name: *const c_char,
+    privdata: *mut c_void,
+) -> c_longlong {
+    let variable = unsafe { &*(privdata as *const T) };
+    // we know the GIL is held so it is safe to use Context::dummy().
+    variable.get(&Context::dummy())
+}
+
+pub fn register_i64_configuration<T: ConfigurationValue<i64>>(
+    ctx: &Context,
+    name: &str,
+    variable: &'static T,
+    default: i64,
+    min: i64,
+    max: i64,
+    flags: ConfigurationFlags,
+) {
+    let name = CString::new(name).unwrap();
+    unsafe {
+        raw::RedisModule_RegisterNumericConfig.unwrap()(
+            ctx.ctx,
+            name.as_ptr(),
+            default,
+            flags.bits() as u32,
+            min,
+            max,
+            Some(i64_configuration_get::<T>),
+            Some(i64_configuration_set::<T>),
+            None,
+            variable as *const T as *mut c_void,
+        );
+    }
+}
+
+extern "C" fn string_configuration_set<T: ConfigurationValue<RedisString>>(
+    _name: *const c_char,
+    val: *mut raw::RedisModuleString,
+    privdata: *mut c_void,
+    err: *mut *mut raw::RedisModuleString,
+) -> c_int {
+    let new_val = RedisString::new(None, val);
+    let variable = unsafe { &*(privdata as *const T) };
+    // we know the GIL is held so it is safe to use Context::dummy().
+    if let Err(e) = variable.set(&Context::dummy(), new_val) {
+        let error_msg = RedisString::create(None, &e.to_string());
+        unsafe { *err = error_msg.take() };
+        return raw::REDISMODULE_ERR as i32;
+    }
+    raw::REDISMODULE_OK as i32
+}
+
+extern "C" fn string_configuration_get<T: ConfigurationValue<RedisString>>(
+    _name: *const c_char,
+    privdata: *mut c_void,
+) -> *mut raw::RedisModuleString {
+    let variable = unsafe { &*(privdata as *const T) };
+    // we know the GIL is held so it is safe to use Context::dummy().
+    variable.get(&Context::dummy()).take()
+}
+
+pub fn register_string_configuration<T: ConfigurationValue<RedisString>>(
+    ctx: &Context,
+    name: &str,
+    variable: &'static T,
+    default: &str,
+    flags: ConfigurationFlags,
+) {
+    let name = CString::new(name).unwrap();
+    let default = CString::new(default).unwrap();
+    unsafe {
+        raw::RedisModule_RegisterStringConfig.unwrap()(
+            ctx.ctx,
+            name.as_ptr(),
+            default.as_ptr(),
+            flags.bits() as u32,
+            Some(string_configuration_get::<T>),
+            Some(string_configuration_set::<T>),
+            None,
+            variable as *const T as *mut c_void,
+        );
+    }
+}
+
+extern "C" fn bool_configuration_set<T: ConfigurationValue<bool>>(
+    _name: *const c_char,
+    val: i32,
+    privdata: *mut c_void,
+    err: *mut *mut raw::RedisModuleString,
+) -> c_int {
+    let variable = unsafe { &*(privdata as *const T) };
+    // we know the GIL is held so it is safe to use Context::dummy().
+    if let Err(e) = variable.set(&Context::dummy(), val != 0) {
+        let error_msg = RedisString::create(None, &e.to_string());
+        unsafe { *err = error_msg.take() };
+        return raw::REDISMODULE_ERR as i32;
+    }
+    raw::REDISMODULE_OK as i32
+}
+
+extern "C" fn bool_configuration_get<T: ConfigurationValue<bool>>(
+    _name: *const c_char,
+    privdata: *mut c_void,
+) -> c_int {
+    let variable = unsafe { &*(privdata as *const T) };
+    // we know the GIL is held so it is safe to use Context::dummy().
+    variable.get(&Context::dummy()) as i32
+}
+
+pub fn register_bool_configuration<T: ConfigurationValue<bool>>(
+    ctx: &Context,
+    name: &str,
+    variable: &'static T,
+    default: bool,
+    flags: ConfigurationFlags,
+) {
+    let name = CString::new(name).unwrap();
+    unsafe {
+        raw::RedisModule_RegisterBoolConfig.unwrap()(
+            ctx.ctx,
+            name.as_ptr(),
+            default as i32,
+            flags.bits() as u32,
+            Some(bool_configuration_get::<T>),
+            Some(bool_configuration_set::<T>),
+            None,
+            variable as *const T as *mut c_void,
+        );
+    }
+}
+
+extern "C" fn enum_configuration_set<G: EnumConfigurationValue, T: ConfigurationValue<G>>(
+    _name: *const c_char,
+    val: i32,
+    privdata: *mut c_void,
+    err: *mut *mut raw::RedisModuleString,
+) -> c_int {
+    let variable = unsafe { &*(privdata as *const T) };
+    // we know the GIL is held so it is safe to use Context::dummy().
+    if let Err(e) = val
+        .try_into()
+        .and_then(|v| variable.set(&Context::dummy(), v))
+    {
+        let error_msg = RedisString::create(None, &e.to_string());
+        unsafe { *err = error_msg.take() };
+        return raw::REDISMODULE_ERR as i32;
+    }
+    raw::REDISMODULE_OK as i32
+}
+
+extern "C" fn enum_configuration_get<G: EnumConfigurationValue, T: ConfigurationValue<G>>(
+    _name: *const c_char,
+    privdata: *mut c_void,
+) -> c_int {
+    let variable = unsafe { &*(privdata as *const T) };
+    // we know the GIL is held so it is safe to use Context::dummy().
+    variable.get(&Context::dummy()).into()
+}
+
+pub fn register_enum_configuration<G: EnumConfigurationValue, T: ConfigurationValue<G>>(
+    ctx: &Context,
+    name: &str,
+    variable: &'static T,
+    default: G,
+    flags: ConfigurationFlags,
+) {
+    let name = CString::new(name).unwrap();
+    let (names, vals) = default.get_options();
+    assert_eq!(names.len(), vals.len());
+    let names: Vec<CString> = names
+        .into_iter()
+        .map(|v| CString::new(v).unwrap())
+        .collect();
+    unsafe {
+        raw::RedisModule_RegisterEnumConfig.unwrap()(
+            ctx.ctx,
+            name.as_ptr(),
+            default.into(),
+            flags.bits() as u32,
+            names
+                .iter()
+                .map(|v| v.as_ptr())
+                .collect::<Vec<*const c_char>>()
+                .as_mut_ptr(),
+            vals.as_ptr(),
+            names.len() as i32,
+            Some(enum_configuration_get::<G, T>),
+            Some(enum_configuration_set::<G, T>),
+            None,
+            variable as *const T as *mut c_void,
+        );
+    }
+}

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -9,30 +9,30 @@ use std::sync::Mutex;
 
 bitflags! {
     /// Configuration options
-    pub struct ConfigurationFlags : c_int {
+    pub struct ConfigurationFlags : u32 {
         /// The default flags for a config. This creates a config that can be modified after startup.
-        const DEFAULT = raw::REDISMODULE_CONFIG_DEFAULT as c_int;
+        const DEFAULT = raw::REDISMODULE_CONFIG_DEFAULT;
 
         /// This config can only be provided loading time.
-        const IMMUTABLE = raw::REDISMODULE_CONFIG_IMMUTABLE as c_int;
+        const IMMUTABLE = raw::REDISMODULE_CONFIG_IMMUTABLE;
 
         /// The value stored in this config is redacted from all logging.
-        const SENSITIVE = raw::REDISMODULE_CONFIG_SENSITIVE as c_int;
+        const SENSITIVE = raw::REDISMODULE_CONFIG_SENSITIVE;
 
         /// The name is hidden from `CONFIG GET` with pattern matching.
-        const HIDDEN = raw::REDISMODULE_CONFIG_HIDDEN as c_int;
+        const HIDDEN = raw::REDISMODULE_CONFIG_HIDDEN;
 
         /// This config will be only be modifiable based off the value of enable-protected-configs.
-        const PROTECTED = raw::REDISMODULE_CONFIG_PROTECTED as c_int;
+        const PROTECTED = raw::REDISMODULE_CONFIG_PROTECTED;
 
         /// This config is not modifiable while the server is loading data.
-        const DENY_LOADING = raw::REDISMODULE_CONFIG_DENY_LOADING as c_int;
+        const DENY_LOADING = raw::REDISMODULE_CONFIG_DENY_LOADING;
 
         /// For numeric configs, this config will convert data unit notations into their byte equivalent.
-        const MEMORY = raw::REDISMODULE_CONFIG_MEMORY as c_int;
+        const MEMORY = raw::REDISMODULE_CONFIG_MEMORY;
 
         /// For enum configs, this config will allow multiple entries to be combined as bit flags.
-        const BITFLAGS = raw::REDISMODULE_CONFIG_BITFLAGS as c_int;
+        const BITFLAGS = raw::REDISMODULE_CONFIG_BITFLAGS;
     }
 }
 

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -79,9 +79,9 @@ macro_rules! enum_configuration {
     }
 }
 
-/// ConfigurationContext is used as a special context that indicate that we are
+/// [`ConfigurationContext`] is used as a special context that indicate that we are
 /// running with the Redis GIL is held but we should not perform all the regular
-/// operation we can perfrom use the regular Context.
+/// operation we can perfrom on the regular Context.
 pub struct ConfigurationContext {
     _dummy: usize, // We set some none public vairable here so user will not be able to construct such object
 }

--- a/src/context/info.rs
+++ b/src/context/info.rs
@@ -1,4 +1,5 @@
 use std::ffi::CString;
+use std::ptr::NonNull;
 
 use crate::Context;
 use crate::{raw, RedisString};
@@ -23,7 +24,7 @@ impl ServerInfo {
         if value.is_null() {
             None
         } else {
-            Some(RedisString::new(self.ctx, value))
+            Some(RedisString::new(NonNull::new(self.ctx), value))
         }
     }
 }

--- a/src/context/keys_cursor.rs
+++ b/src/context/keys_cursor.rs
@@ -3,6 +3,7 @@ use crate::key::RedisKey;
 use crate::raw;
 use crate::redismodule::RedisString;
 use std::ffi::c_void;
+use std::ptr::NonNull;
 
 pub struct KeysCursor {
     inner_cursor: *mut raw::RedisModuleScanCursor,
@@ -15,7 +16,7 @@ extern "C" fn scan_callback<C: FnMut(&Context, RedisString, Option<&RedisKey>)>(
     private_data: *mut ::std::os::raw::c_void,
 ) {
     let context = Context::new(ctx);
-    let key_name = RedisString::new(ctx, key_name);
+    let key_name = RedisString::new(NonNull::new(ctx), key_name);
     let redis_key = if key.is_null() {
         None
     } else {

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -3,6 +3,7 @@ use std::borrow::Borrow;
 use std::ffi::CString;
 use std::os::raw::{c_char, c_int, c_long, c_longlong};
 use std::ptr;
+use std::ptr::NonNull;
 
 use crate::key::{RedisKey, RedisKeyWritable};
 use crate::raw::{ModuleOptions, Version};
@@ -412,7 +413,7 @@ impl Context {
 
     #[must_use]
     pub fn create_string(&self, s: &str) -> RedisString {
-        RedisString::create(self.ctx, s)
+        RedisString::create(NonNull::new(self.ctx), s)
     }
 
     #[must_use]

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -15,6 +15,7 @@ use crate::{RedisError, RedisResult, RedisString, RedisValue};
 use std::ffi::CStr;
 
 use self::call_reply::RootCallReply;
+use self::thread_safe::RedisLockIndicator;
 
 #[cfg(feature = "experimental-api")]
 mod timer;
@@ -564,6 +565,8 @@ impl Context {
         acl_permission_result.map_err(|_e| RedisError::Str("User does not have permissions on key"))
     }
 }
+
+unsafe impl RedisLockIndicator for Context {}
 
 bitflags! {
     /// An object represent ACL permissions.

--- a/src/context/thread_safe.rs
+++ b/src/context/thread_safe.rs
@@ -25,6 +25,24 @@ impl<'ctx, 'mutex, T, G: RedisLockIndicator> DerefMut for RedisGILGuardScope<'ct
     }
 }
 
+/// Whenever the user gets a reference to a struct that
+/// implements this trait, it can assume that the Redis GIL
+/// is held. Any struct that implements this trait can be
+/// used to retrieve objects which are GIL protected (see
+/// [RedisGILGuard] for more information)
+///
+/// Notice that this trait only gives indication that the
+/// GIL is locked, unlike [RedisGILGuard] which protect data
+/// access and make sure the protected data is only accesses
+/// when the GIL is locked.
+///
+/// In general this trait should not be implemented by the
+/// user, the crate knows when the Redis GIL is held and will
+/// make sure to implement this trait correctly on different
+/// struct (such as [Context], [ConfigurationContext], [ContextGuard]).
+/// User might also decide to implement this trait but he should
+/// carefully consider that because it is easy to make mistakes,
+/// this is why the trait is marked as unsafe.
 pub unsafe trait RedisLockIndicator {}
 
 /// This struct allows to guard some data and makes sure

--- a/src/key.rs
+++ b/src/key.rs
@@ -3,6 +3,7 @@ use std::ops::Deref;
 use std::ops::DerefMut;
 use std::os::raw::c_void;
 use std::ptr;
+use std::ptr::NonNull;
 use std::time::Duration;
 
 use libc::size_t;
@@ -252,7 +253,7 @@ impl RedisKeyWritable {
             return None;
         }
 
-        Some(RedisString::new(self.ctx, ptr))
+        Some(RedisString::new(NonNull::new(self.ctx), ptr))
     }
 
     //  `list_pop_head` pops and returns the last element of the list.
@@ -267,7 +268,7 @@ impl RedisKeyWritable {
             return None;
         }
 
-        Some(RedisString::new(self.ctx, ptr))
+        Some(RedisString::new(NonNull::new(self.ctx), ptr))
     }
 
     pub fn set_expire(&self, expire: Duration) -> RedisResult {
@@ -287,7 +288,7 @@ impl RedisKeyWritable {
     }
 
     pub fn write(&self, val: &str) -> RedisResult {
-        let val_str = RedisString::create(self.ctx, val);
+        let val_str = RedisString::create(NonNull::new(self.ctx), val);
         match raw::string_set(self.key_inner, val_str.inner) {
             raw::Status::Ok => REDIS_OK,
             raw::Status::Err => Err(RedisError::Str("Error while setting key")),
@@ -459,7 +460,7 @@ where
     /// use redis_module::{Context, RedisError, RedisResult, RedisString, RedisValue};
     ///
     /// fn call_hash(ctx: &Context, _: Vec<RedisString>) -> RedisResult {
-    ///     let key_name = RedisString::create(ctx.ctx, "config");
+    ///     let key_name = RedisString::create(None, "config");
     ///     let fields = &["username", "password", "email"];
     ///     let hm: HMGetResult<'_, &str, RedisString> = ctx
     ///         .open_key(&key_name)
@@ -477,7 +478,7 @@ where
     /// use redis_module::key::HMGetResult;
     ///
     /// fn call_hash(ctx: &Context, _: Vec<RedisString>) -> RedisResult {
-    ///     let key_name = RedisString::create(ctx.ctx, "config");
+    ///     let key_name = RedisString::create(None, "config");
     ///     let fields = &["username", "password", "email"];
     ///     let hm: HMGetResult<'_, &str, RedisString> = ctx
     ///          .open_key(&key_name)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ pub mod redisraw;
 pub mod redisvalue;
 pub mod stream;
 
+pub mod configuration;
 mod context;
 pub mod key;
 pub mod logging;
@@ -27,6 +28,8 @@ pub use crate::context::thread_safe::{DetachedFromClient, ThreadSafeContext};
 #[cfg(feature = "experimental-api")]
 pub use crate::raw::NotifyEvent;
 
+pub use crate::configuration::ConfigurationValue;
+pub use crate::configuration::EnumConfigurationValue;
 pub use crate::context::call_reply::{CallReply, InnerCallReply, RootCallReply};
 pub use crate::context::keys_cursor::KeysCursor;
 pub use crate::context::server_events;

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -4,9 +4,6 @@ use std::ffi::CString;
 use std::ptr;
 
 pub(crate) fn log_internal(ctx: *mut raw::RedisModuleCtx, level: LogLevel, message: &str) {
-    if cfg!(feature = "test") {
-        return;
-    }
     let level = CString::new(level.as_ref()).unwrap();
     let fmt = CString::new(message).unwrap();
     unsafe { raw::RedisModule_Log.unwrap()(ctx, level.as_ptr(), fmt.as_ptr()) }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -109,6 +109,34 @@ macro_rules! redis_module {
                 $event_handler:expr
             ]),* $(,)*
         ])?
+        $(configurations: [
+            $(i64:[$([
+                $i64_configuration_name:expr,
+                $i64_configuration_val:expr,
+                $i64_default:expr,
+                $i64_min:expr,
+                $i64_max:expr,
+                $i64_flags_options:expr
+            ]),* $(,)*],)?
+            $(string:[$([
+                $string_configuration_name:expr,
+                $string_configuration_val:expr,
+                $string_default:expr,
+                $string_flags_options:expr
+            ]),* $(,)*],)?
+            $(bool:[$([
+                $bool_configuration_name:expr,
+                $bool_configuration_val:expr,
+                $bool_default:expr,
+                $bool_flags_options:expr
+            ]),* $(,)*],)?
+            $(enum:[$([
+                $enum_configuration_name:expr,
+                $enum_configuration_val:expr,
+                $enum_default:expr,
+                $enum_flags_options:expr
+            ]),* $(,)*],)?
+        ])?
     ) => {
         extern "C" fn __info_func(
             ctx: *mut $crate::raw::RedisModuleInfoCtx,
@@ -133,6 +161,10 @@ macro_rules! redis_module {
             use $crate::raw;
             use $crate::RedisString;
             use $crate::server_events::register_server_events;
+            use $crate::configuration::register_i64_configuration;
+            use $crate::configuration::register_string_configuration;
+            use $crate::configuration::register_bool_configuration;
+            use $crate::configuration::register_enum_configuration;
 
             // We use a statically sized buffer to avoid allocating.
             // This is needed since we use a custom allocator that relies on the Redis allocator,
@@ -179,6 +211,31 @@ macro_rules! redis_module {
                     redis_event_handler!(ctx, $(raw::NotifyEvent::$event_type |)+ raw::NotifyEvent::empty(), $event_handler);
                 )*
             )?
+
+            $(
+                $(
+                    $(
+                        register_i64_configuration(&context, $i64_configuration_name, $i64_configuration_val, $i64_default, $i64_min, $i64_max, $i64_flags_options);
+                    )*
+                )?
+                $(
+                    $(
+                        register_string_configuration(&context, $string_configuration_name, $string_configuration_val, $string_default, $string_flags_options);
+                    )*
+                )?
+                $(
+                    $(
+                        register_bool_configuration(&context, $bool_configuration_name, $bool_configuration_val, $bool_default, $bool_flags_options);
+                    )*
+                )?
+                $(
+                    $(
+                        register_enum_configuration(&context, $enum_configuration_name, $enum_configuration_val, $enum_default, $enum_flags_options);
+                    )*
+                )?
+            )?
+
+            raw::RedisModule_LoadConfigs.map(|callback| callback(ctx));
 
             raw::register_info_function(ctx, Some(__info_func));
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -116,25 +116,29 @@ macro_rules! redis_module {
                 $i64_default:expr,
                 $i64_min:expr,
                 $i64_max:expr,
-                $i64_flags_options:expr
+                $i64_flags_options:expr,
+                $i64_on_changed:expr
             ]),* $(,)*],)?
             $(string:[$([
                 $string_configuration_name:expr,
                 $string_configuration_val:expr,
                 $string_default:expr,
-                $string_flags_options:expr
+                $string_flags_options:expr,
+                $string_on_changed:expr
             ]),* $(,)*],)?
             $(bool:[$([
                 $bool_configuration_name:expr,
                 $bool_configuration_val:expr,
                 $bool_default:expr,
-                $bool_flags_options:expr
+                $bool_flags_options:expr,
+                $bool_on_changed:expr
             ]),* $(,)*],)?
             $(enum:[$([
                 $enum_configuration_name:expr,
                 $enum_configuration_val:expr,
                 $enum_default:expr,
-                $enum_flags_options:expr
+                $enum_flags_options:expr,
+                $enum_on_changed:expr
             ]),* $(,)*],)?
         ])?
     ) => {
@@ -215,22 +219,22 @@ macro_rules! redis_module {
             $(
                 $(
                     $(
-                        register_i64_configuration(&context, $i64_configuration_name, $i64_configuration_val, $i64_default, $i64_min, $i64_max, $i64_flags_options);
+                        register_i64_configuration(&context, $i64_configuration_name, $i64_configuration_val, $i64_default, $i64_min, $i64_max, $i64_flags_options, $i64_on_changed);
                     )*
                 )?
                 $(
                     $(
-                        register_string_configuration(&context, $string_configuration_name, $string_configuration_val, $string_default, $string_flags_options);
+                        register_string_configuration(&context, $string_configuration_name, $string_configuration_val, $string_default, $string_flags_options, $string_on_changed);
                     )*
                 )?
                 $(
                     $(
-                        register_bool_configuration(&context, $bool_configuration_name, $bool_configuration_val, $bool_default, $bool_flags_options);
+                        register_bool_configuration(&context, $bool_configuration_name, $bool_configuration_val, $bool_default, $bool_flags_options, $bool_on_changed);
                     )*
                 )?
                 $(
                     $(
-                        register_enum_configuration(&context, $enum_configuration_name, $enum_configuration_val, $enum_default, $enum_flags_options);
+                        register_enum_configuration(&context, $enum_configuration_name, $enum_configuration_val, $enum_default, $enum_flags_options, $enum_on_changed);
                     )*
                 )?
             )?

--- a/src/redismodule.rs
+++ b/src/redismodule.rs
@@ -5,6 +5,7 @@ use std::fmt;
 use std::fmt::Display;
 use std::ops::Deref;
 use std::os::raw::{c_char, c_int, c_void};
+use std::ptr::NonNull;
 use std::slice;
 use std::str;
 use std::str::Utf8Error;
@@ -106,7 +107,7 @@ pub fn decode_args(
 ) -> Vec<RedisString> {
     unsafe { slice::from_raw_parts(argv, argc as usize) }
         .iter()
-        .map(|&arg| RedisString::new(ctx, arg))
+        .map(|&arg| RedisString::new(NonNull::new(ctx), arg))
         .collect()
 }
 
@@ -125,13 +126,18 @@ impl RedisString {
         inner
     }
 
-    pub fn new(ctx: *mut raw::RedisModuleCtx, inner: *mut raw::RedisModuleString) -> Self {
+    pub fn new(
+        ctx: Option<NonNull<raw::RedisModuleCtx>>,
+        inner: *mut raw::RedisModuleString,
+    ) -> Self {
+        let ctx = ctx.map_or(std::ptr::null_mut(), |v| v.as_ptr());
         raw::string_retain_string(ctx, inner);
         Self { ctx, inner }
     }
 
     #[allow(clippy::not_unsafe_ptr_arg_deref)]
-    pub fn create(ctx: *mut raw::RedisModuleCtx, s: &str) -> Self {
+    pub fn create(ctx: Option<NonNull<raw::RedisModuleCtx>>, s: &str) -> Self {
+        let ctx = ctx.map_or(std::ptr::null_mut(), |v| v.as_ptr());
         let str = CString::new(s).unwrap();
         let inner = unsafe { raw::RedisModule_CreateString.unwrap()(ctx, str.as_ptr(), s.len()) };
 
@@ -288,7 +294,7 @@ impl Clone for RedisString {
     fn clone(&self) -> Self {
         let inner =
             unsafe { raw::RedisModule_CreateStringFromString.unwrap()(self.ctx, self.inner) };
-        Self::new(self.ctx, inner)
+        Self::new(NonNull::new(self.ctx), inner)
     }
 }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -454,5 +454,12 @@ fn test_configuration() -> Result<()> {
     config_set("configuration.enum_mutex", "Val2")?;
     assert_eq!(config_get("configuration.enum_mutex")?, "Val2");
 
+    let mut con =
+        get_redis_connection(port).with_context(|| "failed to connect to redis server")?;
+    let res: i64 = redis::cmd("configuration.num_changes")
+        .query(&mut con)
+        .with_context(|| "failed to run flushall")?;
+    assert_eq!(res, 18); // the first configuration initialisation is counted as well, so we will get 18 changes.
+
     Ok(())
 }


### PR DESCRIPTION
The PR adds the ability to add module configuration as using configuration API introduced on Redis 7: https://github.com/redis/redis/pull/10285

The configuration is added optionally on `redis_module!` macro under `configurations` list that can contains the following subsections:

* `i64` configuration:
A list of `i64` configuration in the following format: `[<name>, <reference to the configuration object>, <default value>, <min value>, <max value>, <flags>, <optional on update callback>]`

* `string` configuration:
A list of `string` configuration in the following format: `[<name>, <reference to the configuration object>, <default value>, <flags>, <optional on update callback>]`

* `bool` configuration:
A list of `bool` configuration in the following format: `[<name>, <reference to the configuration object>, <default value>, <flags>, <optional on update callback>]`

* `enum` configuration:
A list of `enum` configuration in the following format: `[<name>, <reference to the configuration object>, <default value>, <flags>, <optional on update callback>]`

An example of all the 4 options can be found under `example/configuration.rs`. Notice that `enum` configuration is of special type and require provide an `enum` that implements the following traits: `TryFrom<i32>`, `From<$name>`, `EnumConfigurationValue`, `Clone`. User can use `enum_configuration` macro to easily added those implementation on a given `enum`.

In addition, it is also possible to tell redismodule-rs to look at the module arguments as if they were configuration using `module_args_as_configuration: true/false` option.

Usage examample:

```rust
/// A macro to easily creating an enum that can be used as an enum configuration
enum_configuration! {
    enum EnumConfiguration {
        Val1 = 1,
        Val2 = 2,
    }
}

/// Static variable that can be used as configuration and will be automatically set when `config set` command is used.
/// All the variables must be somehow thread safe protected, either as atomic variable, `RedisGILGuard` or `Mutex`.
lazy_static! {
    static ref CONFIGURATION_I64: RedisGILGuard<i64> = RedisGILGuard::default();
    static ref CONFIGURATION_ATOMIC_I64: AtomicI64 = AtomicI64::new(1);
    static ref CONFIGURATION_REDIS_STRING: RedisGILGuard<RedisString> =
        RedisGILGuard::new(RedisString::create(None, "default"));
    static ref CONFIGURATION_STRING: RedisGILGuard<String> = RedisGILGuard::new("default".into());
    static ref CONFIGURATION_MUTEX_STRING: Mutex<String> = Mutex::new("default".into());
    static ref CONFIGURATION_ATOMIC_BOOL: AtomicBool = AtomicBool::default();
    static ref CONFIGURATION_BOOL: RedisGILGuard<bool> = RedisGILGuard::default();
    static ref CONFIGURATION_ENUM: RedisGILGuard<EnumConfiguration> =
        RedisGILGuard::new(EnumConfiguration::Val1);
    static ref CONFIGURATION_MUTEX_ENUM: Mutex<EnumConfiguration> =
        Mutex::new(EnumConfiguration::Val1);
}

/// This function will be called when a configuration change is done and will count the total number of changes.
fn num_changes(ctx: &Context, _: Vec<RedisString>) -> RedisResult {
    let val = NUM_OF_CONFIGERATION_CHANGES.lock(ctx);
    Ok(RedisValue::Integer(*val))
}

/// The module initialisation macro, gets the configuration variable and some extra data (such as configuration name and
/// default value) and pass it to Redis so Redis will set them and return their values on `config set` and `config get` respectively.
redis_module! {
    name: "configuration",
    version: 1,
    data_types: [],
    commands: [
        ["configuration.num_changes", num_changes, "", 0, 0, 0],
    ],
    configurations: [
        i64: [
            ["i64", &*CONFIGURATION_I64, 10, 0, 1000, ConfigurationFlags::DEFAULT, Some(Box::new(on_configuration_changed))],
            ["atomic_i64", &*CONFIGURATION_ATOMIC_I64, 10, 0, 1000, ConfigurationFlags::DEFAULT, Some(Box::new(on_configuration_changed))],
        ],
        string: [
            ["redis_string", &*CONFIGURATION_REDIS_STRING, "default", ConfigurationFlags::DEFAULT, Some(Box::new(on_configuration_changed))],
            ["string", &*CONFIGURATION_STRING, "default", ConfigurationFlags::DEFAULT, Some(Box::new(on_configuration_changed::<String, _>))],
            ["mutex_string", &*CONFIGURATION_MUTEX_STRING, "default", ConfigurationFlags::DEFAULT, Some(Box::new(on_configuration_changed::<String, _>))],
        ],
        bool: [
            ["atomic_bool", &*CONFIGURATION_ATOMIC_BOOL, true, ConfigurationFlags::DEFAULT, Some(Box::new(on_configuration_changed))],
            ["bool", &*CONFIGURATION_BOOL, true, ConfigurationFlags::DEFAULT, Some(Box::new(on_configuration_changed))],
        ],
        enum: [
            ["enum", &*CONFIGURATION_ENUM, EnumConfiguration::Val1, ConfigurationFlags::DEFAULT, Some(Box::new(on_configuration_changed))],
            ["enum_mutex", &*CONFIGURATION_MUTEX_ENUM, EnumConfiguration::Val1, ConfigurationFlags::DEFAULT, Some(Box::new(on_configuration_changed))],
        ],
        module_args_as_configuration: true, // Indication that we also want to read module arguments as configuration.
    ]
}
```


- [x] tests
- [x] docs
- [x] Allow passing on_updated callback.
- [x] Change the context ConfigurationValue to some configuration context so user will accidentally perform nonallow operations, like command invocation, inside those callbacks.
- [x] Implement legacy configuration.