### PR TITLE
Fix the backwards compatibility with old Rust.

### DIFF
--- a/src/alloc.rs
+++ b/src/alloc.rs
@@ -9,7 +9,7 @@ use crate::raw;
 /// allocator can't be used. This function makes sure we can panic with
 /// a reasonable message even without the allocator working.
 fn allocation_free_panic(message: &'static str) -> ! {
-    use std::os::fd::AsRawFd;
+    use std::os::unix::io::AsRawFd;
 
     let _ = nix::unistd::write(std::io::stderr().as_raw_fd(), message.as_bytes());
 


### PR DESCRIPTION
The backwards compatibility is broken with the old Rust due to fixing a mistake with imports. This commit uses the direct import for unix systems of the AsRawFd trait and should work on all unix systems.