### PR TITLE
Fix string verbatim reply to work correctly.

### DIFF
--- a/src/context/call_reply.rs
+++ b/src/context/call_reply.rs
@@ -535,7 +535,7 @@ pub struct VerbatimStringCallReply<'root> {
 const VERBATIM_FORMAT_LENGTH: usize = 3;
 /// The string format of a verbatim string ([VerbatimStringCallReply]).
 #[repr(transparent)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Debug, Default, Copy, Clone, PartialEq)]
 pub struct VerbatimStringFormat(pub [char; VERBATIM_FORMAT_LENGTH]);
 
 impl From<&str> for VerbatimStringFormat {

--- a/src/context/call_reply.rs
+++ b/src/context/call_reply.rs
@@ -536,7 +536,7 @@ const VERBATIM_FORMAT_LENGTH: usize = 3;
 /// The string format of a verbatim string ([VerbatimStringCallReply]).
 #[repr(transparent)]
 #[derive(Debug, Default, Copy, Clone, PartialEq)]
-pub struct VerbatimStringFormat(pub [char; VERBATIM_FORMAT_LENGTH]);
+pub struct VerbatimStringFormat(pub [c_char; VERBATIM_FORMAT_LENGTH]);
 
 impl From<&str> for VerbatimStringFormat {
     fn from(value: &str) -> Self {
@@ -546,7 +546,7 @@ impl From<&str> for VerbatimStringFormat {
             .into_iter()
             .take(3)
             .enumerate()
-            .for_each(|(i, c)| res.0[i] = c);
+            .for_each(|(i, c)| res.0[i] = c as c_char);
         res
     }
 }

--- a/src/context/call_reply.rs
+++ b/src/context/call_reply.rs
@@ -531,13 +531,33 @@ pub struct VerbatimStringCallReply<'root> {
     _dummy: PhantomData<&'root ()>,
 }
 
+/// RESP3 state that the verbatim string format must be of length 3.
+const VERBATIM_FORMAT_LENGTH: usize = 3;
+/// The string format of a verbatim string ([VerbatimStringCallReply]).
+#[repr(transparent)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct VerbatimStringFormat(pub [char; VERBATIM_FORMAT_LENGTH]);
+
+impl From<&str> for VerbatimStringFormat {
+    fn from(value: &str) -> Self {
+        let mut res = VerbatimStringFormat::default();
+        value
+            .chars()
+            .into_iter()
+            .take(3)
+            .enumerate()
+            .for_each(|(i, c)| res.0[i] = c);
+        res
+    }
+}
+
 impl<'root> VerbatimStringCallReply<'root> {
     /// Return the verbatim string value of the [VerbatimStringCallReply] as a tuple.
     /// The first entry represents the format, the second entry represent the data.
     /// Return None if the format is not a valid utf8
-    pub fn to_parts(&self) -> Option<(String, Vec<u8>)> {
+    pub fn to_parts(&self) -> Option<(VerbatimStringFormat, Vec<u8>)> {
         self.as_parts()
-            .map(|(format, data)| (format.to_string(), data.to_vec()))
+            .map(|(format, data)| (format.into(), data.to_vec()))
     }
 
     /// Borrow the verbatim string value of the [VerbatimStringCallReply] as a tuple.

--- a/src/context/call_reply.rs
+++ b/src/context/call_reply.rs
@@ -543,9 +543,9 @@ impl TryFrom<&str> for VerbatimStringFormat {
 
     fn try_from(value: &str) -> Result<Self, Self::Error> {
         if value.len() != 3 {
-            return Err(RedisError::String(
-                "Verbatim format len must be 3".to_owned(),
-            ));
+            return Err(RedisError::String(format!(
+                "Verbatim format length must be {VERBATIM_FORMAT_LENGTH}."
+            )));
         }
         let mut res = VerbatimStringFormat::default();
         value

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -429,7 +429,7 @@ impl Context {
                 self.ctx,
                 data.as_ptr().cast(),
                 data.len(),
-                format.as_ptr().cast(),
+                format.0.as_ptr().cast(),
             ),
 
             Ok(RedisValue::BulkRedisString(s)) => raw::reply_with_string(self.ctx, s.inner),

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -425,18 +425,12 @@ impl Context {
                 raw::reply_with_big_number(self.ctx, s.as_ptr().cast::<c_char>(), s.len())
             }
 
-            Ok(RedisValue::VerbatimString((mut format, data))) => {
-                while format.len() < 3 {
-                    // pad the format till it will have 3 chars. Redis will look at those first 3 chars only.
-                    format.push(' ')
-                }
-                raw::reply_with_verbatim_string(
-                    self.ctx,
-                    data.as_ptr().cast(),
-                    data.len(),
-                    format.as_ptr().cast(),
-                )
-            }
+            Ok(RedisValue::VerbatimString((format, data))) => raw::reply_with_verbatim_string(
+                self.ctx,
+                data.as_ptr().cast(),
+                data.len(),
+                format.as_ptr().cast(),
+            ),
 
             Ok(RedisValue::BulkRedisString(s)) => raw::reply_with_string(self.ctx, s.inner),
 

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -432,9 +432,9 @@ impl Context {
                 }
                 raw::reply_with_verbatim_string(
                     self.ctx,
-                    data.as_ptr().cast::<c_char>(),
+                    data.as_ptr().cast(),
                     data.len(),
-                    format.as_ptr().cast::<c_char>(),
+                    format.as_ptr().cast(),
                 )
             }
 

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -425,13 +425,16 @@ impl Context {
                 raw::reply_with_big_number(self.ctx, s.as_ptr().cast::<c_char>(), s.len())
             }
 
-            Ok(RedisValue::VerbatimString((format, mut data))) => {
-                let mut final_data = format.as_bytes().to_vec();
-                final_data.append(&mut data);
+            Ok(RedisValue::VerbatimString((mut format, data))) => {
+                while format.len() < 3 {
+                    // pad the format till it will have 3 chars. Redis will look at those first 3 chars only.
+                    format.push(' ')
+                }
                 raw::reply_with_verbatim_string(
                     self.ctx,
-                    final_data.as_ptr().cast::<c_char>(),
-                    final_data.len(),
+                    data.as_ptr().cast::<c_char>(),
+                    data.len(),
+                    format.as_ptr().cast::<c_char>(),
                 )
             }
 

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -435,8 +435,9 @@ pub fn reply_with_verbatim_string(
     ctx: *mut RedisModuleCtx,
     s: *const c_char,
     len: size_t,
+    format: *const c_char,
 ) -> Status {
-    unsafe { RedisModule_ReplyWithVerbatimString.unwrap()(ctx, s, len).into() }
+    unsafe { RedisModule_ReplyWithVerbatimStringType.unwrap()(ctx, s, len, format).into() }
 }
 
 // Sets the expiry on a key.

--- a/src/redisvalue.rs
+++ b/src/redisvalue.rs
@@ -24,7 +24,7 @@ pub enum RedisValue {
     Bool(bool),
     Float(f64),
     BigNumber(String),
-    VerbatimString((String, Vec<u8>)),
+    VerbatimString(([char; 3], Vec<u8>)),
     Array(Vec<RedisValue>),
     StaticError(&'static str),
     Map(HashMap<RedisValueKey, RedisValue>),
@@ -175,7 +175,16 @@ impl<'root> From<&CallReply<'root>> for RedisValue {
             CallReply::Double(reply) => RedisValue::Float(reply.to_double()),
             CallReply::BigNumber(reply) => RedisValue::BigNumber(reply.to_string().unwrap()),
             CallReply::VerbatimString(reply) => {
-                RedisValue::VerbatimString(reply.to_parts().unwrap())
+                let (f, data) = reply.to_parts().unwrap();
+                let mut format: [char; 3] = ['\0', '\0', '\0'];
+                f.chars()
+                    .into_iter()
+                    .take(3)
+                    .enumerate()
+                    .for_each(|(index, char)| {
+                        format[index] = char;
+                    });
+                RedisValue::VerbatimString((format, data))
             }
         }
     }

--- a/src/redisvalue.rs
+++ b/src/redisvalue.rs
@@ -1,4 +1,7 @@
-use crate::{context::call_reply::CallResult, CallReply, RedisError, RedisString};
+use crate::{
+    context::call_reply::{CallResult, VerbatimStringFormat},
+    CallReply, RedisError, RedisString,
+};
 use std::{
     collections::{HashMap, HashSet},
     hash::Hash,
@@ -24,7 +27,7 @@ pub enum RedisValue {
     Bool(bool),
     Float(f64),
     BigNumber(String),
-    VerbatimString(([char; 3], Vec<u8>)),
+    VerbatimString((VerbatimStringFormat, Vec<u8>)),
     Array(Vec<RedisValue>),
     StaticError(&'static str),
     Map(HashMap<RedisValueKey, RedisValue>),
@@ -175,7 +178,7 @@ impl<'root> From<&CallReply<'root>> for RedisValue {
             CallReply::Double(reply) => RedisValue::Float(reply.to_double()),
             CallReply::BigNumber(reply) => RedisValue::BigNumber(reply.to_string().unwrap()),
             CallReply::VerbatimString(reply) => {
-                RedisValue::VerbatimString(reply.to_parts().map(|(f, data)| (f.0, data)).unwrap())
+                RedisValue::VerbatimString(reply.to_parts().unwrap())
             }
         }
     }

--- a/src/redisvalue.rs
+++ b/src/redisvalue.rs
@@ -175,16 +175,7 @@ impl<'root> From<&CallReply<'root>> for RedisValue {
             CallReply::Double(reply) => RedisValue::Float(reply.to_double()),
             CallReply::BigNumber(reply) => RedisValue::BigNumber(reply.to_string().unwrap()),
             CallReply::VerbatimString(reply) => {
-                let (f, data) = reply.to_parts().unwrap();
-                let mut format: [char; 3] = ['\0', '\0', '\0'];
-                f.chars()
-                    .into_iter()
-                    .take(3)
-                    .enumerate()
-                    .for_each(|(index, char)| {
-                        format[index] = char;
-                    });
-                RedisValue::VerbatimString((format, data))
+                RedisValue::VerbatimString(reply.to_parts().map(|(f, data)| (f.0, data)).unwrap())
             }
         }
     }


### PR DESCRIPTION
Current behaviour is to append to format to the data. This is wrong because the format need to pass separately to Redis. Also, a wrong RedisModuleAPI was used, we need to use the API that allows to pass the format (otherwise Redis uses the default `txt` format).