### PR TITLE
Fix the redis_module macro code.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -54,7 +54,7 @@ fn main() {
     let bindings_generator = bindgen::Builder::default();
 
     let bindings = bindings_generator
-        .clang_arg(&format!("-D{EXPERIMENTAL_API}"))
+        .clang_arg(format!("-D{EXPERIMENTAL_API}"))
         .header("src/include/redismodule.h")
         .allowlist_var("(REDIS|Redis).*")
         .blocklist_type("__darwin_.*")

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -298,13 +298,13 @@ macro_rules! redis_module {
                 raw::RedisModule_LoadConfigs.unwrap()(ctx);
 
                 $(
-                    redis_command!(ctx, $module_config_get_command, |ctx, args: Vec<RedisString>| {
+                    $crate::redis_command!(ctx, $module_config_get_command, |ctx, args: Vec<RedisString>| {
                         module_config_get(ctx, args, $module_name)
                     }, "", 0, 0, 0);
                 )?
 
                 $(
-                    redis_command!(ctx, $module_config_set_command, |ctx, args: Vec<RedisString>| {
+                    $crate::redis_command!(ctx, $module_config_set_command, |ctx, args: Vec<RedisString>| {
                         module_config_set(ctx, args, $module_name)
                     }, "", 0, 0, 0);
                 )?


### PR DESCRIPTION
It should access the internal stuff via the $crate:: path prefix.