### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 [![license](https://img.shields.io/github/license/RedisLabsModules/redismodule-rs.svg)](https://github.com/RedisLabsModules/redismodule-rs/blob/master/LICENSE)
 [![Releases](https://img.shields.io/github/release/RedisLabsModules/redismodule-rs.svg)](https://github.com/RedisLabsModules/redismodule-rs/releases/latest)
 [![crates.io](https://img.shields.io/crates/v/redis-module.svg)](https://crates.io/crates/redis-module)
-[![docs-crates.io](https://shields.io/static/v1?label=docs&message=crates.io&color=9cf)](https://docs.rs/redis-module)
-[![docs-master](https://shields.io/static/v1?label=docs&message=master&color=9cf)](https://docs.rs/redis-module/latest)
+[![docs](https://docs.rs/redis-module/badge.svg)](https://docs.rs/redis-module)
 [![CircleCI](https://circleci.com/gh/RedisLabsModules/redismodule-rs/tree/master.svg?style=svg)](https://circleci.com/gh/RedisLabsModules/redismodule-rs/tree/master)
 
 # redismodule-rs


### PR DESCRIPTION
Remove duplicate links to docs.rs in badges.

The docs.rs/latest and docs.rs links will always be the same, so there is no reason to have both. This was overlooked in the previous badge commits.