### PR TITLE
Fix publish CI

### DIFF
--- a/.github/workflows/cratesio-publish.yml
+++ b/.github/workflows/cratesio-publish.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           file: "Cargo.toml"
           key: "dependencies.redis-module-macros-internals"
-          value: '{ path = "./redismodule-rs-macros-internals", version = "${{ steps.get_version.outputs.VERSION }}" }'
+          value: "{ path = \"./redismodule-rs-macros-internals\", version = \"${{ steps.get_version.outputs.VERSION }}\" }"
 
       - name: Set the version for publishing on macros crate
         uses: ciiiii/toml-editor@1.0.0

--- a/.github/workflows/cratesio-publish.yml
+++ b/.github/workflows/cratesio-publish.yml
@@ -1,7 +1,5 @@
 name: Cratesio Publish
 on:
-  push:
-    branches: [ master ]
   release:
     types: [published]
 

--- a/.github/workflows/cratesio-publish.yml
+++ b/.github/workflows/cratesio-publish.yml
@@ -1,5 +1,7 @@
 name: Cratesio Publish
 on:
+  push:
+    branches: [ master ]
   release:
     types: [published]
 
@@ -49,22 +51,8 @@ jobs:
           key: "package.version"
           value: "${{ steps.get_version.outputs.VERSION }}"
 
-      - name: Publishing redismodule-rs-macros-internals
-        uses: katyo/publish-crates@v1
-        with:
-          registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-          path: './redismodule-rs-macros-internals'
-          args: --allow-dirty
-
-      - name: Publishing redismodule-rs
-        uses: katyo/publish-crates@v1
-        with:
-          registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-          args: --allow-dirty
-
-      - name: Publishing redismodule-rs-macros
-        uses: katyo/publish-crates@v1
-        with:
-          registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-          path: './redismodule-rs-macros'
-          args: --allow-dirty
+      - name: Echo Cargo.toml
+        run: |
+          cat Cargo.toml
+          cat redismodule-rs-macros/Cargo.toml
+          cat redismodule-rs-macros-internals/Cargo.toml

--- a/.github/workflows/cratesio-publish.yml
+++ b/.github/workflows/cratesio-publish.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           file: "Cargo.toml"
           key: "dependencies.redis-module-macros-internals"
-          value: "{ path = \"./redismodule-rs-macros-internals\", version = \"${{ steps.get_version.outputs.VERSION }}\" }"
+          value: { path = "./redismodule-rs-macros-internals", version = "${{ steps.get_version.outputs.VERSION }}" }
 
       - name: Set the version for publishing on macros crate
         uses: ciiiii/toml-editor@1.0.0

--- a/.github/workflows/cratesio-publish.yml
+++ b/.github/workflows/cratesio-publish.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           file: "Cargo.toml"
           key: "dependencies.redis-module-macros-internals"
-          value: { path = "./redismodule-rs-macros-internals", version = "${{ steps.get_version.outputs.VERSION }}" }
+          value: \{ path = "./redismodule-rs-macros-internals", version = "${{ steps.get_version.outputs.VERSION }}" }
 
       - name: Set the version for publishing on macros crate
         uses: ciiiii/toml-editor@1.0.0

--- a/.github/workflows/cratesio-publish.yml
+++ b/.github/workflows/cratesio-publish.yml
@@ -1,9 +1,9 @@
 name: Cratesio Publish
 on:
-  push:
+  pull_request:
     branches: [ master ]
   release:
-    types: [published]
+    types: [ published ]
 
 jobs:
   publish:

--- a/.github/workflows/cratesio-publish.yml
+++ b/.github/workflows/cratesio-publish.yml
@@ -1,9 +1,9 @@
 name: Cratesio Publish
 on:
-  pull_request:
+  push:
     branches: [ master ]
   release:
-    types: [ published ]
+    types: [published]
 
 jobs:
   publish:
@@ -35,7 +35,7 @@ jobs:
         with:
           file: "Cargo.toml"
           key: "dependencies.redis-module-macros-internals"
-          value: \{ path = "./redismodule-rs-macros-internals", version = "${{ steps.get_version.outputs.VERSION }}" }
+          value: "${{ steps.get_version.outputs.VERSION }}"
 
       - name: Set the version for publishing on macros crate
         uses: ciiiii/toml-editor@1.0.0
@@ -51,8 +51,22 @@ jobs:
           key: "package.version"
           value: "${{ steps.get_version.outputs.VERSION }}"
 
-      - name: Echo Cargo.toml
-        run: |
-          cat Cargo.toml
-          cat redismodule-rs-macros/Cargo.toml
-          cat redismodule-rs-macros-internals/Cargo.toml
+      - name: Publishing redismodule-rs-macros-internals
+        uses: katyo/publish-crates@v1
+        with:
+          registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          path: './redismodule-rs-macros-internals'
+          args: --allow-dirty
+
+      - name: Publishing redismodule-rs
+        uses: katyo/publish-crates@v1
+        with:
+          registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          args: --allow-dirty
+
+      - name: Publishing redismodule-rs-macros
+        uses: katyo/publish-crates@v1
+        with:
+          registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          path: './redismodule-rs-macros'
+          args: --allow-dirty


### PR DESCRIPTION
toml-editor can only set strings value. This is good enough for us because we do not really need the `path` argument.