### PR TITLE
Use `BTreeMap` and `BTreeSet` in addition to `HashMap` and `HashSet`.

### DIFF
--- a/examples/response.rs
+++ b/examples/response.rs
@@ -2,7 +2,7 @@ use redis_module::{
     redis_module, redisvalue::RedisValueKey, Context, NextArg, RedisError, RedisResult,
     RedisString, RedisValue,
 };
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet};
 
 fn map_mget(ctx: &Context, args: Vec<RedisString>) -> RedisResult {
     if args.len() < 2 {
@@ -19,7 +19,7 @@ fn map_mget(ctx: &Context, args: Vec<RedisString>) -> RedisResult {
     let res = match values {
         None => RedisValue::Null,
         Some(values) => {
-            let mut map: HashMap<RedisValueKey, RedisValue> = HashMap::with_capacity(fields.len());
+            let mut map: BTreeMap<RedisValueKey, RedisValue> = BTreeMap::new();
             for (field, value) in values.into_iter() {
                 map.insert(
                     RedisValueKey::BulkRedisString(field),
@@ -48,7 +48,7 @@ fn map_unique(ctx: &Context, args: Vec<RedisString>) -> RedisResult {
     let res = match values {
         None => RedisValue::Null,
         Some(values) => {
-            let mut set: HashSet<RedisValueKey> = HashSet::new();
+            let mut set: BTreeSet<RedisValueKey> = BTreeSet::new();
             for (_, value) in values.into_iter() {
                 set.insert(RedisValueKey::BulkRedisString(value));
             }

--- a/examples/response.rs
+++ b/examples/response.rs
@@ -26,7 +26,7 @@ fn map_mget(ctx: &Context, args: Vec<RedisString>) -> RedisResult {
                     RedisValue::BulkRedisString(value),
                 );
             }
-            RedisValue::Map(map)
+            RedisValue::OrderedMap(map)
         }
     };
 
@@ -52,7 +52,7 @@ fn map_unique(ctx: &Context, args: Vec<RedisString>) -> RedisResult {
             for (_, value) in values.into_iter() {
                 set.insert(RedisValueKey::BulkRedisString(value));
             }
-            RedisValue::Set(set)
+            RedisValue::OrderedSet(set)
         }
     };
 

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -459,7 +459,27 @@ impl Context {
                 raw::Status::Ok
             }
 
+            Ok(RedisValue::OrderedMap(map)) => {
+                raw::reply_with_map(self.ctx, map.len() as c_long);
+
+                for (key, value) in map {
+                    self.reply_with_key(key);
+                    self.reply(Ok(value));
+                }
+
+                raw::Status::Ok
+            }
+
             Ok(RedisValue::Set(set)) => {
+                raw::reply_with_set(self.ctx, set.len() as c_long);
+                set.into_iter().for_each(|e| {
+                    self.reply_with_key(e);
+                });
+
+                raw::Status::Ok
+            }
+
+            Ok(RedisValue::OrderedSet(set)) => {
                 raw::reply_with_set(self.ctx, set.len() as c_long);
                 set.into_iter().for_each(|e| {
                     self.reply_with_key(e);

--- a/src/redisvalue.rs
+++ b/src/redisvalue.rs
@@ -3,7 +3,7 @@ use crate::{
     CallReply, RedisError, RedisString,
 };
 use std::{
-    collections::{BTreeMap, BTreeSet},
+    collections::{BTreeMap, BTreeSet, HashMap, HashSet},
     hash::Hash,
 };
 
@@ -30,8 +30,10 @@ pub enum RedisValue {
     VerbatimString((VerbatimStringFormat, Vec<u8>)),
     Array(Vec<RedisValue>),
     StaticError(&'static str),
-    Map(BTreeMap<RedisValueKey, RedisValue>),
-    Set(BTreeSet<RedisValueKey>),
+    Map(HashMap<RedisValueKey, RedisValue>),
+    Set(HashSet<RedisValueKey>),
+    OrderedMap(BTreeMap<RedisValueKey, RedisValue>),
+    OrderedSet(BTreeSet<RedisValueKey>),
     Null,
     NoReply, // No reply at all (as opposed to a Null reply)
 }

--- a/src/redisvalue.rs
+++ b/src/redisvalue.rs
@@ -3,11 +3,11 @@ use crate::{
     CallReply, RedisError, RedisString,
 };
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{BTreeMap, BTreeSet},
     hash::Hash,
 };
 
-#[derive(Debug, PartialEq, Eq, Hash, Clone)]
+#[derive(Debug, PartialEq, Eq, Hash, Clone, PartialOrd, Ord)]
 pub enum RedisValueKey {
     Integer(i64),
     String(String),
@@ -30,8 +30,8 @@ pub enum RedisValue {
     VerbatimString((VerbatimStringFormat, Vec<u8>)),
     Array(Vec<RedisValue>),
     StaticError(&'static str),
-    Map(HashMap<RedisValueKey, RedisValue>),
-    Set(HashSet<RedisValueKey>),
+    Map(BTreeMap<RedisValueKey, RedisValue>),
+    Set(BTreeSet<RedisValueKey>),
     Null,
     NoReply, // No reply at all (as opposed to a Null reply)
 }


### PR DESCRIPTION
The main problem with `HashMap` and `HashSet` is that those are unordered. So we get results in different order each time.

Using `BTreeMap` and `BTreeSet` we will get the results in the same order each time.