### PR TITLE
Extend `RedisValue` derive macro.

### DIFF
--- a/examples/proc_macro_commands.rs
+++ b/examples/proc_macro_commands.rs
@@ -6,7 +6,7 @@ use redis_module_macros::{command, RedisValue};
 
 #[derive(RedisValue)]
 struct RedisValueDeriveInner {
-    i: i64,
+    i1: i64,
 }
 
 #[derive(RedisValue)]
@@ -16,11 +16,19 @@ struct RedisValueDerive {
     s: String,
     u: usize,
     v: Vec<i64>,
+    #[RedisValueAttr{flatten: true}]
+    inner: RedisValueDeriveInner,
     v2: Vec<RedisValueDeriveInner>,
     hash_map: HashMap<String, String>,
     hash_set: HashSet<String>,
     ordered_map: BTreeMap<String, RedisValueDeriveInner>,
     ordered_set: BTreeSet<String>,
+}
+
+#[derive(RedisValue)]
+enum RedisValueEnum {
+    Str(String),
+    RedisValue(RedisValueDerive),
 }
 
 #[command(
@@ -39,23 +47,28 @@ struct RedisValueDerive {
 )]
 fn redis_value_derive(
     _ctx: &Context,
-    _args: Vec<RedisString>,
-) -> Result<RedisValueDerive, RedisError> {
-    Ok(RedisValueDerive {
-        i: 10,
-        f: 1.1,
-        s: "s".to_owned(),
-        u: 20,
-        v: vec![1, 2, 3],
-        v2: vec![
-            RedisValueDeriveInner { i: 1 },
-            RedisValueDeriveInner { i: 2 },
-        ],
-        hash_map: HashMap::from([("key".to_owned(), "val".to_owned())]),
-        hash_set: HashSet::from(["key".to_owned()]),
-        ordered_map: BTreeMap::from([("key".to_owned(), RedisValueDeriveInner { i: 10 })]),
-        ordered_set: BTreeSet::from(["key".to_owned()]),
-    })
+    args: Vec<RedisString>,
+) -> Result<RedisValueEnum, RedisError> {
+    if args.len() > 1 {
+        Ok(RedisValueEnum::Str("OK".to_owned()))
+    } else {
+        Ok(RedisValueEnum::RedisValue(RedisValueDerive {
+            i: 10,
+            f: 1.1,
+            s: "s".to_owned(),
+            u: 20,
+            v: vec![1, 2, 3],
+            inner: RedisValueDeriveInner { i1: 1 },
+            v2: vec![
+                RedisValueDeriveInner { i1: 1 },
+                RedisValueDeriveInner { i1: 2 },
+            ],
+            hash_map: HashMap::from([("key".to_owned(), "val".to_owned())]),
+            hash_set: HashSet::from(["key".to_owned()]),
+            ordered_map: BTreeMap::from([("key".to_owned(), RedisValueDeriveInner { i1: 10 })]),
+            ordered_set: BTreeSet::from(["key".to_owned()]),
+        }))
+    }
 }
 
 #[command(

--- a/redismodule-rs-macros/src/redis_value.rs
+++ b/redismodule-rs-macros/src/redis_value.rs
@@ -1,18 +1,55 @@
 use proc_macro::TokenStream;
+use proc_macro2::Ident;
 use quote::quote;
-use syn::{parse_macro_input, Data, DeriveInput, Fields};
+use serde::Deserialize;
+use serde_syn::{config, from_stream};
+use syn::{
+    parse,
+    parse::{Parse, ParseStream},
+    parse_macro_input, Data, DataEnum, DataStruct, DeriveInput, Fields,
+};
 
-pub fn redis_value(item: TokenStream) -> TokenStream {
-    let struct_input: DeriveInput = parse_macro_input!(item);
-    let struct_data = match struct_input.data {
-        Data::Struct(s) => s,
-        _ => {
-            return quote! {compile_error!("RedisValue derive can only be apply on struct.")}.into()
+/// Generate [From] implementation for [RedisValue] for Enum.
+/// The generated code will simply check the Enum current type (using
+/// a match statement) and will perform [Into] and the matched variant.
+fn enum_redis_value(struct_name: Ident, enum_data: DataEnum) -> TokenStream {
+    let variants = enum_data
+        .variants
+        .into_iter()
+        .map(|v| v.ident)
+        .collect::<Vec<_>>();
+
+    let res = quote! {
+        impl From<#struct_name> for redis_module::redisvalue::RedisValue {
+            fn from(val: #struct_name) -> redis_module::redisvalue::RedisValue {
+                match val {
+                    #(
+                        #struct_name::#variants(v) => v.into(),
+                    )*
+                }
+            }
         }
     };
+    res.into()
+}
 
-    let struct_name = struct_input.ident;
+/// Represent a single field attributes
+#[derive(Debug, Deserialize, Default)]
+struct FieldAttr {
+    flatten: bool,
+}
 
+impl Parse for FieldAttr {
+    fn parse(input: ParseStream) -> parse::Result<Self> {
+        from_stream(config::JSONY, &input)
+    }
+}
+
+/// Generate [From] implementation for [RedisValue] for a struct.
+/// The generated code will create a [RedisValue::Map] element such that
+/// the keys are the fields names and the value are the result of
+/// running [Into] on each field value to convert it to [RedisValue].
+fn struct_redis_value(struct_name: Ident, struct_data: DataStruct) -> TokenStream {
     let fields = match struct_data.fields {
         Fields::Named(f) => f,
         _ => {
@@ -24,29 +61,88 @@ pub fn redis_value(item: TokenStream) -> TokenStream {
         .named
         .into_iter()
         .map(|v| {
-            let name = v.ident.ok_or("Field without a name is not supported.")?;
-            Ok(name)
+            let name = v
+                .ident
+                .ok_or("Field without a name is not supported.".to_owned())?;
+            if v.attrs.len() > 1 {
+                return Err("Expected at most a single attribute for each field".to_owned());
+            }
+            let field_attr = v.attrs.into_iter().next().map_or(
+                Ok::<_, String>(FieldAttr::default()),
+                |attr| {
+                    let tokens = attr.tokens;
+                    let field_attr: FieldAttr =
+                        parse_macro_input::parse(tokens.into()).map_err(|e| format!("{e}"))?;
+                    Ok(field_attr)
+                },
+            )?;
+            Ok((name, field_attr))
         })
-        .collect::<Result<Vec<_>, &str>>();
+        .collect::<Result<Vec<_>, String>>();
 
     let fields = match fields {
         Ok(f) => f,
         Err(e) => return quote! {compile_error!(#e)}.into(),
     };
 
+    let (fields, flattem_fields) = fields.into_iter().fold(
+        (Vec::new(), Vec::new()),
+        |(mut fields, mut flatten_fields), (field, attr)| {
+            if attr.flatten {
+                flatten_fields.push(field);
+            } else {
+                fields.push(field);
+            }
+
+            (fields, flatten_fields)
+        },
+    );
+
     let fields_names: Vec<_> = fields.iter().map(|v| v.to_string()).collect();
 
     let res = quote! {
         impl From<#struct_name> for redis_module::redisvalue::RedisValue {
             fn from(val: #struct_name) -> redis_module::redisvalue::RedisValue {
-                redis_module::redisvalue::RedisValue::OrderedMap(std::collections::BTreeMap::from([
+                let mut fields: std::collections::BTreeMap<redis_module::redisvalue::RedisValueKey, redis_module::redisvalue::RedisValue> = std::collections::BTreeMap::from([
                     #((
                         redis_module::redisvalue::RedisValueKey::String(#fields_names.to_owned()),
                         val.#fields.into()
                     ), )*
-                ]))
+                ]);
+                #(
+                    let flatten_field: std::collections::BTreeMap<redis_module::redisvalue::RedisValueKey, redis_module::redisvalue::RedisValue> = val.#flattem_fields.into();
+                    fields.extend(flatten_field.into_iter());
+                )*
+                redis_module::redisvalue::RedisValue::OrderedMap(fields)
+            }
+        }
+
+        impl From<#struct_name> for std::collections::BTreeMap<redis_module::redisvalue::RedisValueKey, redis_module::redisvalue::RedisValue> {
+            fn from(val: #struct_name) -> std::collections::BTreeMap<redis_module::redisvalue::RedisValueKey, redis_module::redisvalue::RedisValue> {
+                std::collections::BTreeMap::from([
+                    #((
+                        redis_module::redisvalue::RedisValueKey::String(#fields_names.to_owned()),
+                        val.#fields.into()
+                    ), )*
+                ])
             }
         }
     };
     res.into()
+}
+
+/// Implementation for [RedisValue] derive proc macro.
+/// Runs the relevant code generation base on the element
+/// the proc macro was used on. Currently supports Enums and
+/// structs.
+pub fn redis_value(item: TokenStream) -> TokenStream {
+    let struct_input: DeriveInput = parse_macro_input!(item);
+    let struct_name = struct_input.ident;
+    match struct_input.data {
+        Data::Struct(s) => struct_redis_value(struct_name, s),
+        Data::Enum(e) => enum_redis_value(struct_name, e),
+        _ => {
+            return quote! {compile_error!("RedisValue derive can only be apply on struct.")}.into()
+        }
+    }
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -542,7 +542,7 @@ fn test_command_proc_macro() -> Result<()> {
 
 #[test]
 fn test_redis_value_derive() -> Result<()> {
-    let port: u16 = 6497;
+    let port: u16 = 6498;
     let _guards = vec![start_redis_server_with_module("proc_macro_commands", port)
         .with_context(|| "failed to start redis server")?];
     let mut con =
@@ -552,7 +552,14 @@ fn test_redis_value_derive() -> Result<()> {
         .query(&mut con)
         .with_context(|| "failed to run string.set")?;
 
-    assert_eq!(res.as_sequence().unwrap().len(), 20);
+    assert_eq!(res.as_sequence().unwrap().len(), 22);
+
+    let res: String = redis::cmd("redis_value_derive")
+        .arg(&["test"])
+        .query(&mut con)
+        .with_context(|| "failed to run string.set")?;
+
+    assert_eq!(res, "OK");
 
     Ok(())
 }


### PR DESCRIPTION
The PR extend the `RedisValue` derive macro with 2 new capabilities:

1. It is possible to use it on an Enum. In this case, the generated code will check the enum varient (using a match statement) and perform `Into` on the matched varient. This is usefull in case the command returns more than a single reply type and the reply type need to be decided at runtime.

2. It is possible to specify field attribute. that will define a specific behavior about the field. Supported attributes:
   * flatten - indicate to inlines keys from a field into the parent struct. Example: 
      ```rust
      #[derive(RedisValue)]
      struct RedisValueDeriveInner { 
          i2: i64, 
      }
      #[derive(RedisValue)]
      struct RedisValueDerive { 
          i1: i64,
          #[RedisValueAttr{flatten: true}]
          inner: RedisValueDeriveInner 
      }
      ```