### PR TITLE
Revert the "LogLevel" type in the root.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ name = "response"
 crate-type = ["cdylib"]
 
 [dependencies]
-bitflags = "2.1"
+bitflags = "2"
 libc = "0.2"
 enum-primitive-derive = "^0.1"
 num-traits = "^0.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,12 @@ use backtrace::Backtrace;
 /// See [DetachedContext].
 pub static MODULE_CONTEXT: DetachedContext = DetachedContext::new();
 
+#[deprecated(
+    since = "2.1.0",
+    note = "Please use the redis_module::logging::RedisLogLevel directly instead."
+)]
+pub type LogLevel = logging::RedisLogLevel;
+
 pub fn base_info_func(
     ctx: &InfoContext,
     for_crash_report: bool,


### PR DESCRIPTION
To preserve the API compatibility with older versions, it is necessary to allow to continue using the old "LogLevel" type.

This commit brings it back but not as a enum as it had been before it changed, but as a type alias to the new enum. It also marks it as deprecated with a hint.