### PR TITLE
Added cron server event.

### DIFF
--- a/examples/server_events.rs
+++ b/examples/server_events.rs
@@ -3,9 +3,10 @@ use std::sync::atomic::{AtomicI64, Ordering};
 use redis_module::{
     redis_module, server_events::FlushSubevent, Context, RedisResult, RedisString, RedisValue,
 };
-use redis_module_macros::{config_changed_event_handler, flush_event_handler};
+use redis_module_macros::{config_changed_event_handler, cron_event_handler, flush_event_handler};
 
 static NUM_FLUSHES: AtomicI64 = AtomicI64::new(0);
+static NUM_CRONS: AtomicI64 = AtomicI64::new(0);
 static NUM_MAX_MEMORY_CONFIGURATION_CHANGES: AtomicI64 = AtomicI64::new(0);
 
 #[flush_event_handler]
@@ -23,8 +24,17 @@ fn config_changed_event_handler(_ctx: &Context, changed_configs: &[&str]) {
         .map(|_| NUM_MAX_MEMORY_CONFIGURATION_CHANGES.fetch_add(1, Ordering::SeqCst));
 }
 
+#[cron_event_handler]
+fn cron_event_handler(_ctx: &Context, _hz: u64) {
+    NUM_CRONS.fetch_add(1, Ordering::SeqCst);
+}
+
 fn num_flushed(_ctx: &Context, _args: Vec<RedisString>) -> RedisResult {
     Ok(RedisValue::Integer(NUM_FLUSHES.load(Ordering::SeqCst)))
+}
+
+fn num_crons(_ctx: &Context, _args: Vec<RedisString>) -> RedisResult {
+    Ok(RedisValue::Integer(NUM_CRONS.load(Ordering::SeqCst)))
 }
 
 fn num_maxmemory_changes(_ctx: &Context, _args: Vec<RedisString>) -> RedisResult {
@@ -43,5 +53,6 @@ redis_module! {
     commands: [
         ["num_flushed", num_flushed, "readonly", 0, 0, 0],
         ["num_max_memory_changes", num_maxmemory_changes, "readonly", 0, 0, 0],
+        ["num_crons", num_crons, "readonly", 0, 0, 0],
     ],
 }

--- a/redismodule-rs-macros/src/lib.rs
+++ b/redismodule-rs-macros/src/lib.rs
@@ -195,6 +195,28 @@ pub fn config_changed_event_handler(_attr: TokenStream, item: TokenStream) -> To
     gen.into()
 }
 
+/// Proc macro which is set on a function that need to be called on Redis cron.
+/// The function must accept a [Context] and [u64] that represent the cron hz.
+///
+/// Example:
+///
+/// ```rust,no_run,ignore
+/// #[cron_event_handler]
+/// fn cron_event_handler(ctx: &Context, hz: u64) { ... }
+/// ```
+#[proc_macro_attribute]
+pub fn cron_event_handler(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    let ast: ItemFn = match syn::parse(item) {
+        Ok(res) => res,
+        Err(e) => return e.to_compile_error().into(),
+    };
+    let gen = quote! {
+        #[linkme::distributed_slice(redis_module::server_events::CRON_SERVER_EVENTS_LIST)]
+        #ast
+    };
+    gen.into()
+}
+
 /// The macro auto generate a [From] implementation that can convert the struct into [RedisValue].
 ///
 /// Example:

--- a/src/context/call_reply.rs
+++ b/src/context/call_reply.rs
@@ -109,6 +109,8 @@ pub enum ErrorReply<'root> {
     RedisError(ErrorCallReply<'root>),
 }
 
+unsafe impl<'root> Send for ErrorCallReply<'root> {}
+
 impl<'root> ErrorReply<'root> {
     /// Convert [ErrorCallReply] to [String] or [None] if its not a valid utf8.
     pub fn to_utf8_string(&self) -> Option<String> {
@@ -631,6 +633,8 @@ pub enum CallReply<'root> {
     BigNumber(BigNumberCallReply<'root>),
     VerbatimString(VerbatimStringCallReply<'root>),
 }
+
+unsafe impl<'root> Send for CallReply<'root> {}
 
 impl<'root> Display for CallReply<'root> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -411,6 +411,10 @@ fn test_server_event() -> Result<()> {
 
     assert_eq!(res, 2);
 
+    let res: i64 = redis::cmd("num_crons").query(&mut con)?;
+
+    assert!(res > 0);
+
     Ok(())
 }
 


### PR DESCRIPTION
The cron server event will be called whenever Redis runs its cron jobs (usually a few times per second).

Example:

```rust
#[cron_event_handler]
fn cron_event_handler(ctx: &Context, hz: u64) {
    // run some code here that should run periodically.
}
```