### PR TITLE
Fix lifetime warning in Rust 1.70

### DIFF
--- a/src/raw.rs
+++ b/src/raw.rs
@@ -473,7 +473,7 @@ where
 {
     assert_eq!(fields.len(), values.len());
 
-    let mut fi = fields.iter();
+    let mut fi = fields.iter().map(|s| CString::new(s.clone()).unwrap());
     let mut vi = values.iter_mut();
 
     macro_rules! rm {
@@ -491,9 +491,7 @@ where
     }
     macro_rules! f {
         () => {
-            CString::new((*fi.next().unwrap()).clone())
-                .unwrap()
-                .as_ptr()
+            fi.next().unwrap().as_ptr()
         };
     }
     macro_rules! v {

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -473,7 +473,12 @@ where
 {
     assert_eq!(fields.len(), values.len());
 
-    let mut fi = fields.iter().map(|s| CString::new(s.clone()).unwrap());
+    let fields = fields
+        .iter()
+        .map(|e| CString::new(e.clone()))
+        .collect::<Result<Vec<CString>, _>>()?;
+
+    let mut fi = fields.iter();
     let mut vi = values.iter_mut();
 
     macro_rules! rm {


### PR DESCRIPTION
Starting with rustc 1.70.0, the code in raw.rs:hash_get_multi produced the following warnings:

    this `CString` is deallocated at the end of the statement, bind it to a
    variable to extend its lifetime

While it would work in practice due to the underlying implementation just doing pointer juggling, this warning was correct: The CString created within the macro `f` would be destroyed before the reference to the pointer taken from it with `as_ptr` was used.

Resolved by allocating a new Vec that contains the CStrings. This ensures they remain alive until the function returns.