### PR TITLE
Force post notification job callback to static lifetime

### DIFF
--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -796,7 +796,10 @@ impl Context {
         /// as a logical bug that need to be fixed in the module, an attempt to protect against
         /// infinite loops by halting the execution could result in violation of the feature correctness
         /// and so Redis will make no attempt to protect the module from infinite loops.
-        pub fn add_post_notification_job<F: FnOnce(&Context)>(&self, callback: F) -> Status {
+        pub fn add_post_notification_job<F: FnOnce(&Context) + 'static>(
+            &self,
+            callback: F,
+        ) -> Status {
             let callback = Box::into_raw(Box::new(Some(callback)));
             unsafe {
                 RedisModule_AddPostNotificationJob(


### PR DESCRIPTION
Post notification job callback is kept by Redis for unknown time and so we must force it live for the static lifetime. Notice that this does not mean that the value must live forever, it just means that it can not hold any none static references. For more information: https://practice.rs/lifetime/static.html#t-static