### PR TITLE
open key flags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,6 +111,11 @@ commands:
       - install-prerequisites:
           redis_version: <<parameters.redis_version>>
           getredis_params: <<parameters.getredis_params>>
+      - run:
+          name: patch macos tests # Avoid AVX with Regex with CircleCI since virtualization layer doesn't support it. Use sed to replace the relevant entry in cargo.toml
+          command: |
+            if [[ $(uname -s) == Darwin ]]; then sed -i 's/regex = "1"/regex = { version = "1", features = ["perf", "unicode"] }/g' Cargo.toml; fi
+            cat Cargo.toml
       - restore_cache:
           keys:
             - v3-dependencies-{{ arch }}-{{ checksum "Cargo.toml" }}
@@ -118,11 +123,6 @@ commands:
           name: Check formatting
           shell: /bin/bash -l -eo pipefail
           command: make lint
-      - run:
-          name: patch macos tests # Avoid AVX with Regex with CircleCI since virtualization layer doesn't support it. Use sed to replace the relevant entry in cargo.toml
-          command: |
-            if [[ $(uname -s) == Darwin ]]; then sed -i 's/regex = "1"/regex = { version = "1", features = ["perf", "unicode"] }/g' Cargo.toml; fi
-            cat Cargo.toml
       - run:
           name: Build debug
           shell: /bin/bash -l -eo pipefail

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,7 +121,7 @@ commands:
       - run:
           name: patch macos tests # Avoid AVX with Regex with CircleCI since virtualization layer doesn't support it. Use sed to replace the relevant entry in cargo.toml
           command: |
-            if [[ $(uname -s) == Darwin ]]; then sed -i 's/regex = "1"/regex = { version = "1", default-features = ["perf", "unicode"] }/g' Cargo.toml; fi
+            if [[ $(uname -s) == Darwin ]]; then sed -i 's/regex = "1"/regex = { version = "1", features = ["perf", "unicode"] }/g' Cargo.toml; fi
             cat cargo.toml
       - run:
           name: Build debug

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -203,7 +203,7 @@ jobs:
 
   build-macos-x64:
     macos:
-      xcode: 13.2.1
+      xcode: 13.4.1
     resource_class: macos.x86.medium.gen2
     steps:
       - build-steps

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,7 +122,6 @@ commands:
           name: patch macos tests # Avoid AVX with Regex with CircleCI since virtualization layer doesn't support it. Use sed to replace the relevant entry in cargo.toml
           command: |
             if [[ $(uname -s) == Darwin ]]; then sed -i 's/regex = "1"/regex = { version = "1", features = ["perf", "unicode"] }/g' Cargo.toml; fi
-            cat cargo.toml
       - run:
           name: Build debug
           shell: /bin/bash -l -eo pipefail

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,6 +122,7 @@ commands:
           name: patch macos tests # Avoid AVX with Regex with CircleCI since virtualization layer doesn't support it. Use sed to replace the relevant entry in cargo.toml
           command: |
             if [[ $(uname -s) == Darwin ]]; then sed -i 's/regex = "1"/regex = { version = "1", features = ["perf", "unicode"] }/g' Cargo.toml; fi
+            cat Cargo.toml
       - run:
           name: Build debug
           shell: /bin/bash -l -eo pipefail

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,7 +71,7 @@ commands:
     parameters:
       redis_version:
         type: string
-        default: "7.2-rc1"
+        default: "7.2"
       getredis_params:
         type: string
         default: ""
@@ -101,7 +101,7 @@ commands:
         default: ""
       redis_version:
         type: string
-        default: "7.2-rc1"
+        default: "7.2"
       getredis_params:
         type: string
         default: ""
@@ -118,6 +118,9 @@ commands:
           name: Check formatting
           shell: /bin/bash -l -eo pipefail
           command: make lint
+      - run:
+          name: patch macos tests # Avoid AVX with Regex with CircleCI since virtualization layer doesn't support it. Use sed to replace the relevant entry in cargo.toml
+          command: if [[ $(uname -s) == Darwin ]]; then sed -i 's/regex = "1"/regex = { version = "1", default-features = ["perf", "unicode"] }/g' Cargo.toml; fi
       - run:
           name: Build debug
           shell: /bin/bash -l -eo pipefail

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,7 +120,9 @@ commands:
           command: make lint
       - run:
           name: patch macos tests # Avoid AVX with Regex with CircleCI since virtualization layer doesn't support it. Use sed to replace the relevant entry in cargo.toml
-          command: if [[ $(uname -s) == Darwin ]]; then sed -i 's/regex = "1"/regex = { version = "1", default-features = ["perf", "unicode"] }/g' Cargo.toml; fi
+          command: |
+            if [[ $(uname -s) == Darwin ]]; then sed -i 's/regex = "1"/regex = { version = "1", default-features = ["perf", "unicode"] }/g' Cargo.toml; fi
+            cat cargo.toml
       - run:
           name: Build debug
           shell: /bin/bash -l -eo pipefail

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ dump.rdb
 
 # Debugger-related files:
 .gdb_history
+
+venv/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,7 +121,7 @@ bitflags = "2"
 libc = "0.2"
 enum-primitive-derive = "^0.1"
 num-traits = "^0.2"
-regex = "1"
+regex = {version ="1" , features = ["perf", "unicode"]}
 strum_macros = "0.24"
 backtrace = "0.3"
 linkme = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,7 +121,7 @@ bitflags = "2"
 libc = "0.2"
 enum-primitive-derive = "^0.1"
 num-traits = "^0.2"
-regex = {version ="1" , features = ["perf", "unicode", "regex-syntax/default"]}
+regex = {version ="1" , features = ["perf", "unicode"]}
 strum_macros = "0.24"
 backtrace = "0.3"
 linkme = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,6 +112,10 @@ crate-type = ["cdylib"]
 name = "response"
 crate-type = ["cdylib"]
 
+[[example]]
+name = "open_key_with_flags"
+crate-type = ["cdylib"]
+
 [dependencies]
 bitflags = "2"
 libc = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,7 +121,7 @@ bitflags = "2"
 libc = "0.2"
 enum-primitive-derive = "^0.1"
 num-traits = "^0.2"
-regex = {version ="1" , features = ["perf", "unicode"]}
+regex = "1"
 strum_macros = "0.24"
 backtrace = "0.3"
 linkme = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,7 +121,7 @@ bitflags = "2"
 libc = "0.2"
 enum-primitive-derive = "^0.1"
 num-traits = "^0.2"
-regex = {version ="1" , features = ["perf", "unicode"]}
+regex = {version ="1" , features = ["perf", "unicode", "regex-syntax/default"]}
 strum_macros = "0.24"
 backtrace = "0.3"
 linkme = "0.3"

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
-cargo build --features experimental-api,test --all --all-targets
+cargo build --all --all-targets --no-default-features
 
 

--- a/examples/open_key_with_flags.rs
+++ b/examples/open_key_with_flags.rs
@@ -1,0 +1,79 @@
+use std::{thread, time::Duration};
+
+use redis_module::redisvalue::RedisValueKey;
+use redis_module::{redis_module, Context, RedisError, RedisResult, RedisString, NextArg, RedisValue};
+use redis_module::key::KeyFlag;
+
+
+fn extract_expired_keys_from_stats(stats: RedisValue)->i32{
+    match stats{
+        RedisValue::SimpleString(s) => {
+            s.match_indices("expired_keys:")
+                .map(|(i, _)| i)
+                .last()
+                .map(|i| s[i + 13..i + 14].parse::<i32>().expect("error"))
+                .expect("error")
+        },
+        _ => panic!("expired_keys is not an integer"),
+    }
+}
+
+fn read(ctx: &Context, args: Vec<RedisString>) -> RedisResult {
+    if args.len() < 2 {
+        return Err(RedisError::WrongArity);
+    }
+
+    let mut args = args.into_iter().skip(1);
+    let key_name = args.next_arg()?;
+
+    let key = ctx.open_key_writable(&key_name);
+    let stats = ctx.call("info", &["stats"]).expect("error");
+    key.set_expire(Duration::from_millis(1));
+    thread::sleep(Duration::from_millis(1));
+    let key = ctx.open_key_with_flags(&key_name, &[KeyFlag::NOEFFECTS].to_vec());
+    let stats_after = ctx.call("info", &["stats"]).expect("error");
+    let expired_before = extract_expired_keys_from_stats(stats);
+    let expired_after = extract_expired_keys_from_stats(stats_after);
+    let ret = expired_before == expired_after;
+    match ret {
+        true => Ok(RedisValue::SimpleStringStatic("OK")),
+        false => Err(RedisError::String(format!("stats changed {expired_before:?} {expired_after:?}"))),
+    }
+}
+
+fn write(ctx: &Context, args: Vec<RedisString>) -> RedisResult {
+    if args.len() < 2 {
+        return Err(RedisError::WrongArity);
+    }
+
+    let mut args = args.into_iter().skip(1);
+    let key_name = args.next_arg()?;
+
+    let key = ctx.open_key_writable(&key_name);
+    let stats = ctx.call("info", &["stats"]).expect("error");
+    key.set_expire(Duration::from_millis(1));
+    thread::sleep(Duration::from_millis(1));
+    let key = ctx.open_key_writable_with_flags(&key_name, &[KeyFlag::NOEFFECTS].to_vec());
+    let stats_after = ctx.call("info", &["stats"]).expect("error");
+    
+    let expired_before = extract_expired_keys_from_stats(stats);
+    let expired_after = extract_expired_keys_from_stats(stats_after);
+    let ret = expired_before == expired_after;
+    match ret {
+        true => Ok(RedisValue::SimpleStringStatic("OK")),
+        false => Err(RedisError::String(format!("stats changed {expired_before:?} {expired_after:?}"))),
+    }
+}
+
+//////////////////////////////////////////////////////
+
+redis_module! {
+    name: "open_key_with_flags",
+    version: 1,
+    allocator: (redis_module::alloc::RedisAlloc, redis_module::alloc::RedisAlloc),
+    data_types: [],
+    commands: [
+        ["open_key_with_flags.read", read, "write fast deny-oom", 1, 1, 1],
+        ["open_key_with_flags.write", write, "write fast deny-oom", 1, 1, 1]
+    ],
+}

--- a/examples/open_key_with_flags.rs
+++ b/examples/open_key_with_flags.rs
@@ -21,7 +21,7 @@ fn validate_open_key_with_no_effects(ctx: &Context, key_name: RedisString, read_
     let key = ctx.open_key_writable(&key_name);
     let stats = ctx.call("info", &["stats"])?;
     key.set_expire(Duration::from_millis(1));
-    thread::sleep(Duration::from_millis(1));
+    thread::sleep(Duration::from_millis(2));
     if read_write {
         ctx.open_key_writable_with_flags(&key_name, raw::KeyMode::NOEFFECTS);
     } else {

--- a/examples/open_key_with_flags.rs
+++ b/examples/open_key_with_flags.rs
@@ -1,6 +1,5 @@
 use std::{thread, time::Duration};
 
-use redis_module::redisvalue::RedisValueKey;
 use redis_module::{redis_module, Context, RedisError, RedisResult, RedisString, NextArg, RedisValue};
 use redis_module::key::KeyFlag;
 
@@ -30,7 +29,7 @@ fn read(ctx: &Context, args: Vec<RedisString>) -> RedisResult {
     let stats = ctx.call("info", &["stats"]).expect("error");
     key.set_expire(Duration::from_millis(1));
     thread::sleep(Duration::from_millis(1));
-    let key = ctx.open_key_with_flags(&key_name, &[KeyFlag::NOEFFECTS].to_vec());
+    ctx.open_key_with_flags(&key_name, &[KeyFlag::NOEFFECTS].to_vec());
     let stats_after = ctx.call("info", &["stats"]).expect("error");
     let expired_before = extract_expired_keys_from_stats(stats);
     let expired_after = extract_expired_keys_from_stats(stats_after);
@@ -53,7 +52,7 @@ fn write(ctx: &Context, args: Vec<RedisString>) -> RedisResult {
     let stats = ctx.call("info", &["stats"]).expect("error");
     key.set_expire(Duration::from_millis(1));
     thread::sleep(Duration::from_millis(1));
-    let key = ctx.open_key_writable_with_flags(&key_name, &[KeyFlag::NOEFFECTS].to_vec());
+    ctx.open_key_writable_with_flags(&key_name, &[KeyFlag::NOEFFECTS].to_vec());
     let stats_after = ctx.call("info", &["stats"]).expect("error");
     
     let expired_before = extract_expired_keys_from_stats(stats);

--- a/examples/open_key_with_flags.rs
+++ b/examples/open_key_with_flags.rs
@@ -1,22 +1,57 @@
 use std::{thread, time::Duration};
 
-use redis_module::{redis_module, Context, RedisError, RedisResult, RedisString, NextArg, RedisValue};
-use redis_module::key::KeyFlag;
+use redis_module::{redis_module, Context, RedisError, RedisResult, RedisString, NextArg, RedisValue, raw};
+use redis_module_macros::command;
 
 
-fn extract_expired_keys_from_stats(stats: RedisValue)->i32{
+fn extract_expired_keys_from_stats(stats: RedisValue)->Result<i32, String>{
     match stats{
         RedisValue::SimpleString(s) => {
-            s.match_indices("expired_keys:")
+            let val = s.match_indices("expired_keys:")
                 .map(|(i, _)| i)
                 .last()
-                .map(|i| s[i + 13..i + 14].parse::<i32>().expect("error"))
-                .expect("error")
+                .map(|i| s[i + 13..i + 14].parse::<i32>()).unwrap();
+            Ok(val.ok().unwrap())
         },
-        _ => panic!("expired_keys is not an integer"),
+        _ => Err("expired_keys is not an integer".to_string()),
     }
 }
 
+fn validate_open_key_with_no_effects(ctx: &Context, key_name: RedisString, read_write: bool) -> RedisResult {
+    let key = ctx.open_key_writable(&key_name);
+    let stats = ctx.call("info", &["stats"])?;
+    key.set_expire(Duration::from_millis(1));
+    thread::sleep(Duration::from_millis(1));
+    if read_write {
+        ctx.open_key_writable_with_flags(&key_name, raw::KeyMode::NOEFFECTS);
+    } else {
+        ctx.open_key_with_flags(&key_name, raw::KeyMode::NOEFFECTS);
+    }
+    let stats_after = ctx.call("info", &["stats"])?;
+    let expired_before = extract_expired_keys_from_stats(stats);
+    let expired_after = extract_expired_keys_from_stats(stats_after);
+    if expired_before == expired_after {
+        Ok(RedisValue::SimpleStringStatic("OK"))
+    } else {
+        Err(RedisError::String(format!("stats changed {expired_before:?} {expired_after:?}")))
+    }
+}
+
+#[command(
+    {
+        name: "open_key_with_flags.read",
+        flags: [Write, DenyOOM],
+        arity: 2,
+        key_spec: [
+            {
+                flags: [ReadOnly, Access],
+                begin_search: Index({ index : 1 }),
+                find_keys: Range({ last_key : 1, steps : 1, limit : 1}),
+            }
+        ]
+
+    }
+)]
 fn read(ctx: &Context, args: Vec<RedisString>) -> RedisResult {
     if args.len() < 2 {
         return Err(RedisError::WrongArity);
@@ -24,22 +59,25 @@ fn read(ctx: &Context, args: Vec<RedisString>) -> RedisResult {
 
     let mut args = args.into_iter().skip(1);
     let key_name = args.next_arg()?;
-
-    let key = ctx.open_key_writable(&key_name);
-    let stats = ctx.call("info", &["stats"]).expect("error");
-    key.set_expire(Duration::from_millis(1));
-    thread::sleep(Duration::from_millis(1));
-    ctx.open_key_with_flags(&key_name, &[KeyFlag::NOEFFECTS].to_vec());
-    let stats_after = ctx.call("info", &["stats"]).expect("error");
-    let expired_before = extract_expired_keys_from_stats(stats);
-    let expired_after = extract_expired_keys_from_stats(stats_after);
-    let ret = expired_before == expired_after;
-    match ret {
-        true => Ok(RedisValue::SimpleStringStatic("OK")),
-        false => Err(RedisError::String(format!("stats changed {expired_before:?} {expired_after:?}"))),
-    }
+    validate_open_key_with_no_effects(ctx, key_name, false)
 }
 
+
+#[command(
+    {
+        name: "open_key_with_flags.write",
+        flags: [Write, DenyOOM],
+        arity: 2,
+        key_spec: [
+            {
+                flags: [ReadWrite, Access],
+                begin_search: Index({ index : 1 }),
+                find_keys: Range({ last_key : 1, steps : 1, limit : 1}),
+            }
+        ]
+
+    }
+)]
 fn write(ctx: &Context, args: Vec<RedisString>) -> RedisResult {
     if args.len() < 2 {
         return Err(RedisError::WrongArity);
@@ -47,21 +85,7 @@ fn write(ctx: &Context, args: Vec<RedisString>) -> RedisResult {
 
     let mut args = args.into_iter().skip(1);
     let key_name = args.next_arg()?;
-
-    let key = ctx.open_key_writable(&key_name);
-    let stats = ctx.call("info", &["stats"]).expect("error");
-    key.set_expire(Duration::from_millis(1));
-    thread::sleep(Duration::from_millis(1));
-    ctx.open_key_writable_with_flags(&key_name, &[KeyFlag::NOEFFECTS].to_vec());
-    let stats_after = ctx.call("info", &["stats"]).expect("error");
-    
-    let expired_before = extract_expired_keys_from_stats(stats);
-    let expired_after = extract_expired_keys_from_stats(stats_after);
-    let ret = expired_before == expired_after;
-    match ret {
-        true => Ok(RedisValue::SimpleStringStatic("OK")),
-        false => Err(RedisError::String(format!("stats changed {expired_before:?} {expired_after:?}"))),
-    }
+    validate_open_key_with_no_effects(ctx, key_name, true)
 }
 
 //////////////////////////////////////////////////////
@@ -71,8 +95,5 @@ redis_module! {
     version: 1,
     allocator: (redis_module::alloc::RedisAlloc, redis_module::alloc::RedisAlloc),
     data_types: [],
-    commands: [
-        ["open_key_with_flags.read", read, "write fast deny-oom", 1, 1, 1],
-        ["open_key_with_flags.write", write, "write fast deny-oom", 1, 1, 1]
-    ],
+    commands: [],
 }

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -7,7 +7,7 @@ use std::os::raw::{c_char, c_int, c_long, c_longlong};
 use std::ptr::{self, NonNull};
 use std::sync::atomic::{AtomicPtr, Ordering};
 
-use crate::key::{RedisKey, RedisKeyWritable};
+use crate::key::{KeyFlags, RedisKey, RedisKeyWritable};
 use crate::logging::RedisLogLevel;
 use crate::raw::{ModuleOptions, Version};
 use crate::redisvalue::RedisValueKey;
@@ -613,12 +613,11 @@ impl Context {
     pub fn open_key(&self, key: &RedisString) -> RedisKey {
         RedisKey::open(self.ctx, key)
     }
-    
+
     #[must_use]
-    pub fn open_key_with_flags(&self, key: &RedisString, flags: raw::KeyMode) -> RedisKey {
+    pub fn open_key_with_flags(&self, key: &RedisString, flags: KeyFlags) -> RedisKey {
         RedisKey::open_with_flags(self.ctx, key, flags)
     }
-
 
     #[must_use]
     pub fn open_key_writable(&self, key: &RedisString) -> RedisKeyWritable {
@@ -626,7 +625,11 @@ impl Context {
     }
 
     #[must_use]
-    pub fn open_key_writable_with_flags(&self, key: &RedisString, flags: raw::KeyMode) -> RedisKeyWritable {
+    pub fn open_key_writable_with_flags(
+        &self,
+        key: &RedisString,
+        flags: KeyFlags,
+    ) -> RedisKeyWritable {
         RedisKeyWritable::open_with_flags(self.ctx, key, flags)
     }
 

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -7,7 +7,7 @@ use std::os::raw::{c_char, c_int, c_long, c_longlong};
 use std::ptr::{self, NonNull};
 use std::sync::atomic::{AtomicPtr, Ordering};
 
-use crate::key::{RedisKey, RedisKeyWritable};
+use crate::key::{RedisKey, RedisKeyWritable, KeyFlag};
 use crate::logging::RedisLogLevel;
 use crate::raw::{ModuleOptions, Version};
 use crate::redisvalue::RedisValueKey;
@@ -613,10 +613,21 @@ impl Context {
     pub fn open_key(&self, key: &RedisString) -> RedisKey {
         RedisKey::open(self.ctx, key)
     }
+    
+    #[must_use]
+    pub fn open_key_with_flags(&self, key: &RedisString, flags: &Vec<KeyFlag>) -> RedisKey {
+        RedisKey::open_with_flags(self.ctx, key, flags)
+    }
+
 
     #[must_use]
     pub fn open_key_writable(&self, key: &RedisString) -> RedisKeyWritable {
         RedisKeyWritable::open(self.ctx, key)
+    }
+
+    #[must_use]
+    pub fn open_key_writable_with_flags(&self, key: &RedisString, flags: &Vec<KeyFlag>) -> RedisKeyWritable {
+        RedisKeyWritable::open_with_flags(self.ctx, key, flags)
     }
 
     pub fn replicate_verbatim(&self) {

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -7,7 +7,7 @@ use std::os::raw::{c_char, c_int, c_long, c_longlong};
 use std::ptr::{self, NonNull};
 use std::sync::atomic::{AtomicPtr, Ordering};
 
-use crate::key::{RedisKey, RedisKeyWritable, KeyFlag};
+use crate::key::{RedisKey, RedisKeyWritable};
 use crate::logging::RedisLogLevel;
 use crate::raw::{ModuleOptions, Version};
 use crate::redisvalue::RedisValueKey;
@@ -615,7 +615,7 @@ impl Context {
     }
     
     #[must_use]
-    pub fn open_key_with_flags(&self, key: &RedisString, flags: &Vec<KeyFlag>) -> RedisKey {
+    pub fn open_key_with_flags(&self, key: &RedisString, flags: raw::KeyMode) -> RedisKey {
         RedisKey::open_with_flags(self.ctx, key, flags)
     }
 
@@ -626,7 +626,7 @@ impl Context {
     }
 
     #[must_use]
-    pub fn open_key_writable_with_flags(&self, key: &RedisString, flags: &Vec<KeyFlag>) -> RedisKeyWritable {
+    pub fn open_key_writable_with_flags(&self, key: &RedisString, flags: raw::KeyMode) -> RedisKeyWritable {
         RedisKeyWritable::open_with_flags(self.ctx, key, flags)
     }
 

--- a/src/key.rs
+++ b/src/key.rs
@@ -68,7 +68,7 @@ impl RedisKey {
         Self { ctx, key_inner }
     }
 
-    pub fn open_with_flags(
+    pub(crate) fn open_with_flags(
         ctx: *mut raw::RedisModuleCtx,
         key: &RedisString,
         flags: KeyFlags,
@@ -204,7 +204,7 @@ impl RedisKeyWritable {
         Self { ctx, key_inner }
     }
 
-    pub fn open_with_flags(
+    pub(crate) fn open_with_flags(
         ctx: *mut raw::RedisModuleCtx,
         key: &RedisString,
         flags: KeyFlags,

--- a/src/key.rs
+++ b/src/key.rs
@@ -32,6 +32,21 @@ pub enum KeyMode {
     ReadWrite,
 }
 
+/// RedisModule_OpenKey extra flags for the 'mode' argument
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum KeyFlag {
+    /// Avoid touching the LRU/LFU of the key when opened.
+    NOTOUCH,
+    /// Don't trigger keyspace event on key misses.
+    NONOTIFY,
+    /// Don't update keyspace hits/misses counters
+    NOSTATS,
+    /// Avoid deleting lazy expired keys.
+    NOEXPIRE,
+    /// Avoid any effects from fetching the key.
+    NOEFFECTS
+}
+
 #[derive(Debug)]
 pub struct RedisKey {
     pub(crate) ctx: *mut raw::RedisModuleCtx,
@@ -47,6 +62,11 @@ impl RedisKey {
 
     pub fn open(ctx: *mut raw::RedisModuleCtx, key: &RedisString) -> Self {
         let key_inner = raw::open_key(ctx, key.inner, to_raw_mode(KeyMode::Read));
+        Self { ctx, key_inner }
+    }
+
+    pub fn open_with_flags(ctx: *mut raw::RedisModuleCtx, key: &RedisString, flags: &Vec<KeyFlag>) -> Self {
+        let key_inner = raw::open_key(ctx, key.inner, to_raw_mode(KeyMode::Read) |  to_raw_flags(flags));
         Self { ctx, key_inner }
     }
 
@@ -173,6 +193,11 @@ pub struct RedisKeyWritable {
 impl RedisKeyWritable {
     pub fn open(ctx: *mut raw::RedisModuleCtx, key: &RedisString) -> Self {
         let key_inner = raw::open_key(ctx, key.inner, to_raw_mode(KeyMode::ReadWrite));
+        Self { ctx, key_inner }
+    }
+
+    pub fn open_with_flags(ctx: *mut raw::RedisModuleCtx, key: &RedisString, flags: &Vec<KeyFlag>) -> Self {
+        let key_inner = raw::open_key(ctx, key.inner,  to_raw_mode(KeyMode::ReadWrite) |  to_raw_flags(flags));
         Self { ctx, key_inner }
     }
 
@@ -605,6 +630,22 @@ fn to_raw_mode(mode: KeyMode) -> raw::KeyMode {
         KeyMode::Read => raw::KeyMode::READ,
         KeyMode::ReadWrite => raw::KeyMode::READ | raw::KeyMode::WRITE,
     }
+}
+
+fn to_raw_flag(flag: KeyFlag)->raw::KeyMode {
+    match flag {
+        KeyFlag::NOTOUCH => raw::KeyMode::NOTOUCH,
+        KeyFlag::NONOTIFY => raw::KeyMode::NONOTIFY,
+        KeyFlag::NOSTATS => raw::KeyMode::NOSTATS,
+        KeyFlag::NOEXPIRE => raw::KeyMode::NOEXPIRE,
+        KeyFlag::NOEFFECTS => raw::KeyMode::NOEFFECTS,
+    }
+}
+
+fn to_raw_flags(flags: &Vec<KeyFlag>) -> raw::KeyMode {
+    flags.iter().fold(raw::KeyMode::empty(), |acc, flag| {
+        acc | to_raw_flag(*flag)
+    })
 }
 
 /// # Panics

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -29,6 +29,17 @@ bitflags! {
     pub struct KeyMode: c_int {
         const READ = REDISMODULE_READ as c_int;
         const WRITE = REDISMODULE_WRITE as c_int;
+
+        /// Avoid touching the LRU/LFU of the key when opened.
+        const NOTOUCH = REDISMODULE_OPEN_KEY_NOTOUCH as c_int;
+        /// Don't trigger keyspace event on key misses.
+        const NONOTIFY = REDISMODULE_OPEN_KEY_NONOTIFY as c_int;
+        /// Don't update keyspace hits/misses counters.
+        const NOSTATS = REDISMODULE_OPEN_KEY_NOSTATS as c_int;
+        /// Avoid deleting lazy expired keys.
+        const NOEXPIRE = REDISMODULE_OPEN_KEY_NOEXPIRE as c_int;
+        /// Avoid any effects from fetching the key.
+        const NOEFFECTS = REDISMODULE_OPEN_KEY_NOEFFECTS as c_int;
     }
 }
 

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -29,17 +29,6 @@ bitflags! {
     pub struct KeyMode: c_int {
         const READ = REDISMODULE_READ as c_int;
         const WRITE = REDISMODULE_WRITE as c_int;
-
-        /// Avoid touching the LRU/LFU of the key when opened.
-        const NOTOUCH = REDISMODULE_OPEN_KEY_NOTOUCH as c_int;
-        /// Don't trigger keyspace event on key misses.
-        const NONOTIFY = REDISMODULE_OPEN_KEY_NONOTIFY as c_int;
-        /// Don't update keyspace hits/misses counters.
-        const NOSTATS = REDISMODULE_OPEN_KEY_NOSTATS as c_int;
-        /// Avoid deleting lazy expired keys.
-        const NOEXPIRE = REDISMODULE_OPEN_KEY_NOEXPIRE as c_int;
-        /// Avoid any effects from fetching the key.
-        const NOEFFECTS = REDISMODULE_OPEN_KEY_NOEFFECTS as c_int;
     }
 }
 
@@ -357,6 +346,19 @@ pub fn open_key(
     mode: KeyMode,
 ) -> *mut RedisModuleKey {
     unsafe { RedisModule_OpenKey.unwrap()(ctx, keyname, mode.bits()).cast::<RedisModuleKey>() }
+}
+
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
+#[inline]
+pub(crate) fn open_key_with_flags(
+    ctx: *mut RedisModuleCtx,
+    keyname: *mut RedisModuleString,
+    mode: KeyMode,
+    flags: c_int,
+) -> *mut RedisModuleKey {
+    unsafe {
+        RedisModule_OpenKey.unwrap()(ctx, keyname, mode.bits() | flags).cast::<RedisModuleKey>()
+    }
 }
 
 #[allow(clippy::not_unsafe_ptr_arg_deref)]

--- a/test.sh
+++ b/test.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env sh
-cargo test --all-targets --features test,experimental-api
+cargo test --all --all-targets --no-default-features

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,3 +1,6 @@
+use std::thread;
+use std::time::Duration;
+
 use crate::utils::{get_redis_connection, start_redis_server_with_module};
 use anyhow::Context;
 use anyhow::Result;
@@ -653,13 +656,58 @@ fn test_open_key_with_flags() -> Result<()> {
     let _guards = vec![start_redis_server_with_module("open_key_with_flags", port)
         .with_context(|| "failed to start redis server")?];
     let mut con =
-    get_redis_connection(port).with_context(|| "failed to connect to redis server")?;
+        get_redis_connection(port).with_context(|| "failed to connect to redis server")?;
 
-    let res = redis::cmd("open_key_with_flags.read").arg(&["x"]).query(&mut con);
-    assert_eq!(res, Ok(()));
+    // Avoid active expriation
+    redis::cmd("DEBUG")
+        .arg(&["SET-ACTIVE-EXPIRE", "0"])
+        .query(&mut con)
+        .with_context(|| "failed to run DEBUG SET-ACTIVE-EXPIRE")?;
 
-    let res = redis::cmd("open_key_with_flags.write").arg(&["x"]).query(&mut con);
-    assert_eq!(res, Ok(()));
+    for read_write in [true, false].iter() {
+        redis::cmd("set")
+            .arg(&["x", "1"])
+            .query(&mut con)
+            .with_context(|| "failed to run string.set")?;
+
+        // Set experition time to 1 second.
+        redis::cmd("expire")
+            .arg(&["x", "1"])
+            .query(&mut con)
+            .with_context(|| "failed to run expire")?;
+
+        // Sleep for 2 seconds, ensure expiration time has passed.
+        thread::sleep(Duration::from_secs(2));
+
+        let cmd = if *read_write {
+            "open_key_with_flags.write"
+        } else {
+            "open_key_with_flags.read"
+        };
+
+        // Open key as read only or ReadWrite with NOEFFECTS flag.
+        let res = redis::cmd(cmd).arg(&["x"]).query(&mut con);
+        assert_eq!(res, Ok(()));
+
+        // Get the number of expired keys.
+        let stats: String = redis::cmd("info").arg(&["stats"]).query(&mut con)?;
+
+        // Find the number of expired keys, x,  according to the substring "expired_keys:{x}"
+        let expired_keys = stats
+            .match_indices("expired_keys:")
+            .next()
+            .map(|(i, _)| &stats[i..i + "expired_keys:".len() + 1])
+            .and_then(|s| s.split(':').nth(1))
+            .and_then(|s| s.parse::<i32>().ok())
+            .unwrap_or(-1);
+
+        // Ensure that no keys were expired.
+        assert_eq!(expired_keys, 0);
+
+        // Delete key and reset stats
+        redis::cmd("del").arg(&["x"]).query(&mut con)?;
+        redis::cmd("config").arg(&["RESETSTAT"]).query(&mut con)?;
+    }
 
     Ok(())
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -679,7 +679,6 @@ fn test_open_key_with_flags() -> Result<()> {
         // Sleep for 2 seconds, ensure expiration time has passed.
         thread::sleep(Duration::from_millis(500));
 
-
         // Open key as read only or ReadWrite with NOEFFECTS flag.
         let res = redis::cmd(cmd).arg(&["x"]).query(&mut con);
         assert_eq!(res, Ok(()));

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -649,7 +649,7 @@ fn test_call_blocking() -> Result<()> {
 
 #[test]
 fn test_open_key_with_flags() -> Result<()> {
-    let port: u16 = 6500;
+    let port: u16 = 6501;
     let _guards = vec![start_redis_server_with_module("open_key_with_flags", port)
         .with_context(|| "failed to start redis server")?];
     let mut con =

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -647,19 +647,19 @@ fn test_call_blocking() -> Result<()> {
     Ok(())
 }
 
-// #[test]
-// fn test_open_key_with_flags() -> Result<()> {
-//     let port: u16 = 6500;
-//     let _guards = vec![start_redis_server_with_module("open_key_with_flags", port)
-//         .with_context(|| "failed to start redis server")?];
-//     let mut con =
-//     get_redis_connection(port).with_context(|| "failed to connect to redis server")?;
+#[test]
+fn test_open_key_with_flags() -> Result<()> {
+    let port: u16 = 6500;
+    let _guards = vec![start_redis_server_with_module("open_key_with_flags", port)
+        .with_context(|| "failed to start redis server")?];
+    let mut con =
+    get_redis_connection(port).with_context(|| "failed to connect to redis server")?;
 
-//     let res = redis::cmd("open_key_with_flags.read").arg(&["x"]).query(&mut con);
-//     assert_eq!(res, Ok(()));
+    let res = redis::cmd("open_key_with_flags.read").arg(&["x"]).query(&mut con);
+    assert_eq!(res, Ok(()));
 
-//     let res = redis::cmd("open_key_with_flags.write").arg(&["x"]).query(&mut con);
-//     assert_eq!(res, Ok(()));
+    let res = redis::cmd("open_key_with_flags.write").arg(&["x"]).query(&mut con);
+    assert_eq!(res, Ok(()));
 
-//     Ok(())
-// }
+    Ok(())
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -671,13 +671,13 @@ fn test_open_key_with_flags() -> Result<()> {
             .with_context(|| "failed to run string.set")?;
 
         // Set experition time to 1 second.
-        redis::cmd("expire")
+        redis::cmd("pexpire")
             .arg(&["x", "1"])
             .query(&mut con)
             .with_context(|| "failed to run expire")?;
 
         // Sleep for 2 seconds, ensure expiration time has passed.
-        thread::sleep(Duration::from_secs(2));
+        thread::sleep(Duration::from_millis(500));
 
 
         // Open key as read only or ReadWrite with NOEFFECTS flag.
@@ -688,10 +688,12 @@ fn test_open_key_with_flags() -> Result<()> {
         let stats: String = redis::cmd("info").arg(&["stats"]).query(&mut con)?;
 
         // Find the number of expired keys, x,  according to the substring "expired_keys:{x}"
-        use redis_module::utils::get_regexp_captures;
-        let expired_keys = get_regexp_captures(stats.as_str(), r"\bexpired_keys:([0-9]+)\b")
-            .unwrap()[0]
-            .parse::<i32>()
+        let expired_keys = stats
+            .match_indices("expired_keys:")
+            .next()
+            .map(|(i, _)| &stats[i..i + "expired_keys:".len() + 1])
+            .and_then(|s| s.split(':').nth(1))
+            .and_then(|s| s.parse::<i32>().ok())
             .unwrap_or(-1);
 
         // Ensure that no keys were expired.

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -646,3 +646,20 @@ fn test_call_blocking() -> Result<()> {
 
     Ok(())
 }
+
+// #[test]
+// fn test_open_key_with_flags() -> Result<()> {
+//     let port: u16 = 6500;
+//     let _guards = vec![start_redis_server_with_module("open_key_with_flags", port)
+//         .with_context(|| "failed to start redis server")?];
+//     let mut con =
+//     get_redis_connection(port).with_context(|| "failed to connect to redis server")?;
+
+//     let res = redis::cmd("open_key_with_flags.read").arg(&["x"]).query(&mut con);
+//     assert_eq!(res, Ok(()));
+
+//     let res = redis::cmd("open_key_with_flags.write").arg(&["x"]).query(&mut con);
+//     assert_eq!(res, Ok(()));
+
+//     Ok(())
+// }

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -56,6 +56,8 @@ pub fn start_redis_server_with_module(module_name: &str, port: u16) -> Result<Ch
         &port.to_string(),
         "--loadmodule",
         module_path.as_str(),
+        "--enable-debug-command",
+        "yes",
     ];
 
     let redis_server = Command::new("redis-server")


### PR DESCRIPTION
This PR adds the ability to open key for read or write with additional flags
It adds the function `open_with_flags` both for `RedisKeyWritable` and `RedisKey` as well as the following flags:
```
    /// Avoid touching the LRU/LFU of the key when opened.
    NOTOUCH,
    /// Don't trigger keyspace event on key misses.
    NONOTIFY,
    /// Don't update keyspace hits/misses counters
    NOSTATS,
    /// Avoid deleting lazy expired keys.
    NOEXPIRE,
    /// Avoid any effects from fetching the key.
    NOEFFECTS
```