### PR TITLE
Added support for _proxy-filtered flag.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,7 +114,7 @@ commands:
       - run:
           name: patch macos tests # Avoid AVX with Regex with CircleCI since virtualization layer doesn't support it. Use sed to replace the relevant entry in cargo.toml
           command: |
-            if [[ $(uname -s) == Darwin ]]; then sed -i 's/regex = "1"/regex = { version = "1", features = ["perf", "unicode"] }/g' Cargo.toml; fi
+            if [[ $(uname -s) == Darwin ]]; then sed -i 's/regex = "1"/regex = { version = "1", features = ["perf", "unicode"], default-features = false }/g' Cargo.toml; fi
             cat Cargo.toml
       - restore_cache:
           keys:

--- a/redismodule-rs-macros/src/lib.rs
+++ b/redismodule-rs-macros/src/lib.rs
@@ -9,7 +9,8 @@ mod redis_value;
 /// This proc macro allow to specify that the follow function is a Redis command.
 /// The macro accept the following arguments that discribe the command properties:
 /// * name (optional) - The command name. in case not given, the function name will be taken.
-/// * flags - An array of `RedisCommandFlags`.
+/// * flags - An array of [`command::RedisCommandFlags`].
+/// * enterprise_flags - An array of [`command::RedisEnterpriseCommandFlags`].
 /// * summary (optional) - Command summary
 /// * complexity (optional) - Command compexity
 /// * since (optional) - At which module version the command was first introduce

--- a/src/context/commands.rs
+++ b/src/context/commands.rs
@@ -377,9 +377,9 @@ api! {[
             let name: CString = CString::new(command_info.name.as_str()).unwrap();
             let mut flags = command_info.flags.as_deref().unwrap_or("").to_owned();
             if is_enterprise {
-                flags = format!("{flags} {}", command_info.enterprise_flags.as_deref().unwrap_or(""));
+                flags = format!("{flags} {}", command_info.enterprise_flags.as_deref().unwrap_or("")).trim().to_owned();
             }
-            let flags = CString::new(flags).unwrap();
+            let flags = CString::new(flags).map_err(|e| RedisError::String(e.to_string()))?;
 
             if unsafe {
                 RedisModule_CreateCommand(

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -857,13 +857,16 @@ impl Context {
         let info_res = self.call("info", &["server"])?;
         match info_res {
             RedisValue::BulkRedisString(res) => Ok(res.try_as_str()?.contains("rlec_version:")),
-            _ => Err(RedisError::Str("Missmatch call reply type")),
+            _ => Err(RedisError::Str("Mismatch call reply type")),
         }
     }
 
     /// Return `true` is the current Redis deployment is enterprise, otherwise `false`.
     pub fn is_enterprise(&self) -> bool {
-        self.is_enterprise_internal().unwrap_or(false)
+        self.is_enterprise_internal().unwrap_or_else(|e| {
+            log::error!("Failed getting deployment type, assuming oss. Error: {e}.");
+            false
+        })
     }
 }
 

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -850,6 +850,21 @@ impl Context {
             unsafe { RedisModule_AvoidReplicaTraffic() == 1 }
         }
     );
+
+    /// Return [Ok(true)] is the current Redis deployment is enterprise, otherwise [Ok(false)].
+    /// Return error in case it was not possible to determind the deployment.
+    fn is_enterprise_internal(&self) -> Result<bool, RedisError> {
+        let info_res = self.call("info", &["server"])?;
+        match info_res {
+            RedisValue::BulkRedisString(res) => Ok(res.try_as_str()?.contains("rlec_version:")),
+            _ => Err(RedisError::Str("Missmatch call reply type")),
+        }
+    }
+
+    /// Return `true` is the current Redis deployment is enterprise, otherwise `false`.
+    pub fn is_enterprise(&self) -> bool {
+        self.is_enterprise_internal().unwrap_or(false)
+    }
 }
 
 extern "C" fn post_notification_job_free_callback<F: FnOnce(&Context)>(pd: *mut c_void) {


### PR DESCRIPTION
The new flag is an enterprise only flag. The new flag will make sure the command will not appeared on slow log, `command` command, and other location where we do not want to expose it.