### PR TITLE
Enable diskless replication by supporting async load

### DIFF
--- a/src/raw.rs
+++ b/src/raw.rs
@@ -36,6 +36,7 @@ bitflags! {
     pub struct ModuleOptions: c_int {
         const HANDLE_IO_ERRORS = REDISMODULE_OPTIONS_HANDLE_IO_ERRORS as c_int;
         const NO_IMPLICIT_SIGNAL_MODIFIED = REDISMODULE_OPTION_NO_IMPLICIT_SIGNAL_MODIFIED as c_int;
+        const HANDLE_REPL_ASYNC_LOAD = REDISMODULE_OPTIONS_HANDLE_REPL_ASYNC_LOAD as c_int;
     }
 }
 


### PR DESCRIPTION
Add `module_option_handle_repl_async_load` flag to module options