### PR TITLE
Added support for defrag API.

### DIFF
--- a/examples/data_type.rs
+++ b/examples/data_type.rs
@@ -127,7 +127,7 @@ fn alloc_defragstats(ctx: &Context, _args: Vec<RedisString>) -> RedisResult {
     let num_defrag_start = NUM_DEFRAG_START.lock(ctx);
     let num_defrag_end = NUM_DEFRAG_END.lock(ctx);
     Ok(RedisValue::OrderedMap(
-        vec![
+        [
             (
                 RedisValueKey::String("num_keys_defrag".to_owned()),
                 RedisValue::Integer(*num_keys_defrag as i64),

--- a/examples/data_type.rs
+++ b/examples/data_type.rs
@@ -1,10 +1,24 @@
+use lazy_static::lazy_static;
+use libc::c_int;
+use redis_module::defrag::DefragContext;
 use redis_module::native_types::RedisType;
-use redis_module::{raw, redis_module, Context, NextArg, RedisResult, RedisString};
+use redis_module::redisvalue::RedisValueKey;
+use redis_module::{
+    raw, redis_module, Context, NextArg, RedisGILGuard, RedisResult, RedisString, RedisValue,
+};
+use redis_module_macros::{defrag_end_function, defrag_function, defrag_start_function};
 use std::os::raw::c_void;
 
 #[derive(Debug)]
 struct MyType {
     data: String,
+}
+
+lazy_static! {
+    static ref NUM_KEYS_DEFRAG: RedisGILGuard<usize> = RedisGILGuard::default();
+    static ref NUM_DEFRAG_START: RedisGILGuard<usize> = RedisGILGuard::default();
+    static ref NUM_DEFRAG_END: RedisGILGuard<usize> = RedisGILGuard::default();
+    static ref NUM_DEFRAG_GLOBALS: RedisGILGuard<usize> = RedisGILGuard::default();
 }
 
 static MY_REDIS_TYPE: RedisType = RedisType::new(
@@ -30,7 +44,7 @@ static MY_REDIS_TYPE: RedisType = RedisType::new(
         free_effort: None,
         unlink: None,
         copy: None,
-        defrag: None,
+        defrag: Some(defrag),
 
         copy2: None,
         free_effort2: None,
@@ -41,6 +55,35 @@ static MY_REDIS_TYPE: RedisType = RedisType::new(
 
 unsafe extern "C" fn free(value: *mut c_void) {
     drop(Box::from_raw(value.cast::<MyType>()));
+}
+
+unsafe extern "C" fn defrag(
+    ctx: *mut raw::RedisModuleDefragCtx,
+    _key: *mut raw::RedisModuleString,
+    _value: *mut *mut c_void,
+) -> c_int {
+    let defrag_ctx = DefragContext::new(ctx);
+    let mut num_keys_defrag = NUM_KEYS_DEFRAG.lock(&defrag_ctx);
+    *num_keys_defrag += 1;
+    0
+}
+
+#[defrag_start_function]
+fn defrag_end(defrag_ctx: &DefragContext) {
+    let mut num_defrag_end = NUM_DEFRAG_END.lock(defrag_ctx);
+    *num_defrag_end += 1;
+}
+
+#[defrag_end_function]
+fn defrag_start(defrag_ctx: &DefragContext) {
+    let mut num_defrag_start = NUM_DEFRAG_START.lock(defrag_ctx);
+    *num_defrag_start += 1;
+}
+
+#[defrag_function]
+fn defrag_globals(defrag_ctx: &DefragContext) {
+    let mut num_defrag_globals = NUM_DEFRAG_GLOBALS.lock(defrag_ctx);
+    *num_defrag_globals += 1;
 }
 
 fn alloc_set(ctx: &Context, args: Vec<RedisString>) -> RedisResult {
@@ -78,6 +121,35 @@ fn alloc_get(ctx: &Context, args: Vec<RedisString>) -> RedisResult {
     Ok(value)
 }
 
+fn alloc_defragstats(ctx: &Context, _args: Vec<RedisString>) -> RedisResult {
+    let num_keys_defrag = NUM_KEYS_DEFRAG.lock(ctx);
+    let num_defrag_globals = NUM_DEFRAG_GLOBALS.lock(ctx);
+    let num_defrag_start = NUM_DEFRAG_START.lock(ctx);
+    let num_defrag_end = NUM_DEFRAG_END.lock(ctx);
+    Ok(RedisValue::OrderedMap(
+        vec![
+            (
+                RedisValueKey::String("num_keys_defrag".to_owned()),
+                RedisValue::Integer(*num_keys_defrag as i64),
+            ),
+            (
+                RedisValueKey::String("num_defrag_globals".to_owned()),
+                RedisValue::Integer(*num_defrag_globals as i64),
+            ),
+            (
+                RedisValueKey::String("num_defrag_start".to_owned()),
+                RedisValue::Integer(*num_defrag_start as i64),
+            ),
+            (
+                RedisValueKey::String("num_defrag_end".to_owned()),
+                RedisValue::Integer(*num_defrag_end as i64),
+            ),
+        ]
+        .into_iter()
+        .collect(),
+    ))
+}
+
 //////////////////////////////////////////////////////
 
 redis_module! {
@@ -90,5 +162,6 @@ redis_module! {
     commands: [
         ["alloc.set", alloc_set, "write", 1, 1, 1],
         ["alloc.get", alloc_get, "readonly", 1, 1, 1],
+        ["alloc.defragstats", alloc_defragstats, "readonly", 0, 0, 0]
     ],
 }

--- a/examples/open_key_with_flags.rs
+++ b/examples/open_key_with_flags.rs
@@ -1,6 +1,5 @@
 use redis_module::{
-    key::KeyFlags, raw, redis_module, Context, NextArg, RedisError, RedisResult, RedisString,
-    RedisValue,
+    key::KeyFlags, redis_module, Context, NextArg, RedisError, RedisResult, RedisString, RedisValue,
 };
 use redis_module_macros::command;
 

--- a/redismodule-rs-macros/src/lib.rs
+++ b/redismodule-rs-macros/src/lib.rs
@@ -451,3 +451,72 @@ pub fn info_command_handler(_attr: TokenStream, item: TokenStream) -> TokenStrea
 pub fn info_section(item: TokenStream) -> TokenStream {
     info_section::info_section(item)
 }
+
+/// Proc macro which is set on a function that need to be called whenever server performs defrag.
+/// The function must accept a [&DefragContext]. If defrag is not supported by the Redis version
+/// the function will never be called.
+///
+/// Example:
+///
+/// ```rust,no_run,ignore
+/// #[defrag_function]
+/// fn defrag(ctx: &DefragContext) { ... }
+/// ```
+#[proc_macro_attribute]
+pub fn defrag_function(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    let ast: ItemFn = match syn::parse(item) {
+        Ok(res) => res,
+        Err(e) => return e.to_compile_error().into(),
+    };
+    let gen = quote! {
+        #[linkme::distributed_slice(redis_module::defrag::DEFRAG_FUNCTIONS_LIST)]
+        #ast
+    };
+    gen.into()
+}
+
+/// Proc macro which is set on a function that need to be called whenever server start performs defrag.
+/// The function must accept a [&DefragContext]. If defrag start event is not supported by the Redis version
+/// the function will never be called.
+///
+/// Example:
+///
+/// ```rust,no_run,ignore
+/// #[defrag_start_function]
+/// fn defrag_start(ctx: &DefragContext) { ... }
+/// ```
+#[proc_macro_attribute]
+pub fn defrag_start_function(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    let ast: ItemFn = match syn::parse(item) {
+        Ok(res) => res,
+        Err(e) => return e.to_compile_error().into(),
+    };
+    let gen = quote! {
+        #[linkme::distributed_slice(redis_module::defrag::DEFRAG_START_FUNCTIONS_LIST)]
+        #ast
+    };
+    gen.into()
+}
+
+/// Proc macro which is set on a function that need to be called whenever server end performs defrag.
+/// The function must accept a [&DefragContext]. If defrag end event is not supported by the Redis version
+/// the function will never be called.
+///
+/// Example:
+///
+/// ```rust,no_run,ignore
+/// #[defrag_end_function]
+/// fn defrag_end(ctx: &DefragContext) { ... }
+/// ```
+#[proc_macro_attribute]
+pub fn defrag_end_function(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    let ast: ItemFn = match syn::parse(item) {
+        Ok(res) => res,
+        Err(e) => return e.to_compile_error().into(),
+    };
+    let gen = quote! {
+        #[linkme::distributed_slice(redis_module::defrag::DEFRAG_END_FUNCTIONS_LIST)]
+        #ast
+    };
+    gen.into()
+}

--- a/redismodule-rs-macros/src/lib.rs
+++ b/redismodule-rs-macros/src/lib.rs
@@ -464,7 +464,10 @@ pub fn info_section(item: TokenStream) -> TokenStream {
 /// ```
 #[proc_macro_attribute]
 pub fn defrag_function(_attr: TokenStream, item: TokenStream) -> TokenStream {
-    let ast: ItemFn = syn::parse(item).unwrap_or_else(|e| e.to_compile_error().into());
+    let ast: ItemFn = match syn::parse(item) {
+        Ok(res) => res,
+        Err(e) => return e.to_compile_error().into(),
+    };
     let gen = quote! {
         #[linkme::distributed_slice(redis_module::defrag::DEFRAG_FUNCTIONS_LIST)]
         #ast
@@ -484,7 +487,10 @@ pub fn defrag_function(_attr: TokenStream, item: TokenStream) -> TokenStream {
 /// ```
 #[proc_macro_attribute]
 pub fn defrag_start_function(_attr: TokenStream, item: TokenStream) -> TokenStream {
-    let ast: ItemFn = syn::parse(item).unwrap_or_else(|e| e.to_compile_error().into());
+    let ast: ItemFn = match syn::parse(item) {
+        Ok(res) => res,
+        Err(e) => return e.to_compile_error().into(),
+    };
     let gen = quote! {
         #[linkme::distributed_slice(redis_module::defrag::DEFRAG_START_FUNCTIONS_LIST)]
         #ast
@@ -504,7 +510,10 @@ pub fn defrag_start_function(_attr: TokenStream, item: TokenStream) -> TokenStre
 /// ```
 #[proc_macro_attribute]
 pub fn defrag_end_function(_attr: TokenStream, item: TokenStream) -> TokenStream {
-    let ast: ItemFn = syn::parse(item).unwrap_or_else(|e| e.to_compile_error().into());
+    let ast: ItemFn = match syn::parse(item) {
+        Ok(res) => res,
+        Err(e) => return e.to_compile_error().into(),
+    };
     let gen = quote! {
         #[linkme::distributed_slice(redis_module::defrag::DEFRAG_END_FUNCTIONS_LIST)]
         #ast

--- a/redismodule-rs-macros/src/lib.rs
+++ b/redismodule-rs-macros/src/lib.rs
@@ -464,10 +464,7 @@ pub fn info_section(item: TokenStream) -> TokenStream {
 /// ```
 #[proc_macro_attribute]
 pub fn defrag_function(_attr: TokenStream, item: TokenStream) -> TokenStream {
-    let ast: ItemFn = match syn::parse(item) {
-        Ok(res) => res,
-        Err(e) => return e.to_compile_error().into(),
-    };
+    let ast: ItemFn = syn::parse(item).unwrap_or_else(|e| e.to_compile_error().into());
     let gen = quote! {
         #[linkme::distributed_slice(redis_module::defrag::DEFRAG_FUNCTIONS_LIST)]
         #ast
@@ -487,10 +484,7 @@ pub fn defrag_function(_attr: TokenStream, item: TokenStream) -> TokenStream {
 /// ```
 #[proc_macro_attribute]
 pub fn defrag_start_function(_attr: TokenStream, item: TokenStream) -> TokenStream {
-    let ast: ItemFn = match syn::parse(item) {
-        Ok(res) => res,
-        Err(e) => return e.to_compile_error().into(),
-    };
+    let ast: ItemFn = syn::parse(item).unwrap_or_else(|e| e.to_compile_error().into());
     let gen = quote! {
         #[linkme::distributed_slice(redis_module::defrag::DEFRAG_START_FUNCTIONS_LIST)]
         #ast
@@ -510,10 +504,7 @@ pub fn defrag_start_function(_attr: TokenStream, item: TokenStream) -> TokenStre
 /// ```
 #[proc_macro_attribute]
 pub fn defrag_end_function(_attr: TokenStream, item: TokenStream) -> TokenStream {
-    let ast: ItemFn = match syn::parse(item) {
-        Ok(res) => res,
-        Err(e) => return e.to_compile_error().into(),
-    };
+    let ast: ItemFn = syn::parse(item).unwrap_or_else(|e| e.to_compile_error().into());
     let gen = quote! {
         #[linkme::distributed_slice(redis_module::defrag::DEFRAG_END_FUNCTIONS_LIST)]
         #ast

--- a/src/context/commands.rs
+++ b/src/context/commands.rs
@@ -454,12 +454,12 @@ api! {[
             // the only CString pointers which are not freed are those of the key_specs, lets free them here.
             key_specs.into_iter().for_each(|v|{
                 if !v.notes.is_null() {
-                    unsafe{CString::from_raw(v.notes as *mut c_char)};
+                    drop(unsafe{CString::from_raw(v.notes as *mut c_char)});
                 }
                 if v.begin_search_type == raw::RedisModuleKeySpecBeginSearchType_REDISMODULE_KSPEC_BS_KEYWORD {
                     let keyword = unsafe{v.bs.keyword.keyword};
                     if !keyword.is_null() {
-                        unsafe{CString::from_raw(v.bs.keyword.keyword as *mut c_char)};
+                        drop(unsafe{CString::from_raw(v.bs.keyword.keyword as *mut c_char)});
                     }
                 }
             });

--- a/src/context/defrag.rs
+++ b/src/context/defrag.rs
@@ -1,0 +1,226 @@
+use std::alloc::Layout;
+
+use crate::{
+    raw, Context, RedisModule_DefragAlloc, RedisModule_DefragCursorGet,
+    RedisModule_DefragCursorSet, RedisModule_DefragRedisModuleString, RedisModule_DefragShouldStop,
+    RedisString, Status,
+};
+use crate::{RedisError, RedisLockIndicator};
+use linkme::distributed_slice;
+
+pub struct DefragContext {
+    defrag_ctx: *mut raw::RedisModuleDefragCtx,
+}
+
+/// Having a [DefragContext] is indication that we are
+/// currently holding the Redis GIL, this is why it is safe to
+/// implement a [RedisLockIndicator] for [DefragContext].
+unsafe impl RedisLockIndicator for DefragContext {}
+
+impl DefragContext {
+    /// Creates a new [`DefragContext`] from a poiter to [`raw::RedisModuleDefragCtx`].
+    /// The function is considered unsafe because the provided pointer
+    /// must be a valid pointer to [`raw::RedisModuleDefragCtx`], and the Redis GIL must be held.
+    /// The function is exposed for users that wants to implement the defrag function
+    /// on their module datatype, they can use this function to create [`DefragContext`]
+    /// that can be used in a safely manner.
+    /// Notice that the returned [`DefragContext`] borrows the pointer to [`raw::RedisModuleDefragCtx`]
+    /// so it can not outlive it (this means that it should not be used once the defrag callback ends).
+    pub unsafe fn new(defrag_ctx: *mut raw::RedisModuleDefragCtx) -> DefragContext {
+        DefragContext { defrag_ctx }
+    }
+
+    /// When the data type defrag callback iterates complex structures, this
+    /// function should be called periodically. A [`false`] return
+    /// indicates the callback may continue its work. A [`true`]
+    /// indicates it should stop.
+    ///
+    /// When stopped, the callback may use [`Self::set_cursor`] to store its
+    /// position so it can later use [`Self::get_cursor`] to resume defragging.
+    ///
+    /// When stopped and more work is left to be done, the callback should
+    /// return 1. Otherwise, it should return 0.
+    ///
+    /// NOTE: Modules should consider the frequency in which this function is called,
+    /// so it generally makes sense to do small batches of work in between calls.
+    pub fn should_stop(&self) -> bool {
+        let should_stop = unsafe {
+            RedisModule_DefragShouldStop.expect("RedisModule_DefragShouldStop is NULL")(
+                self.defrag_ctx,
+            )
+        };
+        should_stop != 0
+    }
+
+    /// Store an arbitrary cursor value for future re-use.
+    ///
+    /// This should only be called if [`Self::should_stop`] has returned a non-zero
+    /// value and the defrag callback is about to exit without fully iterating its
+    /// data type.
+    ///
+    /// This behavior is reserved to cases where late defrag is performed. Late
+    /// defrag is selected for keys that implement the `free_effort` callback and
+    /// return a `free_effort` value that is larger than the defrag
+    /// 'active-defrag-max-scan-fields' configuration directive.
+    ///
+    /// Smaller keys, keys that do not implement `free_effort` or the global
+    /// defrag callback are not called in late-defrag mode. In those cases, a
+    /// call to this function will return [`Status::Err`].
+    ///
+    /// The cursor may be used by the module to represent some progress into the
+    /// module's data type. Modules may also store additional cursor-related
+    /// information locally and use the cursor as a flag that indicates when
+    /// traversal of a new key begins. This is possible because the API makes
+    /// a guarantee that concurrent defragmentation of multiple keys will
+    /// not be performed.
+    pub fn set_cursor(&self, cursor: u64) -> Status {
+        unsafe {
+            RedisModule_DefragCursorSet.expect("RedisModule_DefragCursorSet is NULL")(
+                self.defrag_ctx,
+                cursor,
+            )
+        }
+        .into()
+    }
+
+    /// Fetch a cursor value that has been previously stored using [`Self::set_cursor`].
+    /// If not called for a late defrag operation, [`Err`] will be returned.
+    pub fn get_cursor(&self) -> Result<u64, RedisError> {
+        let mut cursor: u64 = 0;
+        let res: Status = unsafe {
+            RedisModule_DefragCursorGet.expect("RedisModule_DefragCursorGet is NULL")(
+                self.defrag_ctx,
+                (&mut cursor) as *mut u64,
+            )
+        }
+        .into();
+        if res == Status::Ok {
+            Ok(cursor)
+        } else {
+            Err(RedisError::Str("Could not get cursor value"))
+        }
+    }
+
+    /// Defrag a memory allocation previously allocated by RM_Alloc, RM_Calloc, etc.
+    /// The defragmentation process involves allocating a new memory block and copying
+    /// the contents to it, like realloc().
+    ///
+    /// If defragmentation was not necessary, NULL is returned and the operation has
+    /// no other effect.
+    ///
+    /// If a non-NULL value is returned, the caller should use the new pointer instead
+    /// of the old one and update any reference to the old pointer, which must not
+    /// be used again.
+    ///
+    /// The function is unsafe because it is assumed that the pointer is valid and previusly
+    /// allocated. It is considered undefined if this is not the case.
+    pub unsafe fn defrag_realloc<T>(&self, mut ptr: *mut T) -> *mut T {
+        let new_ptr: *mut T = RedisModule_DefragAlloc.expect("RedisModule_DefragAlloc is NULL")(
+            self.defrag_ctx,
+            ptr.cast(),
+        )
+        .cast();
+        if !new_ptr.is_null() {
+            ptr = new_ptr;
+        }
+        ptr
+    }
+
+    /// Allocate memory using defrag allocator if supported by the
+    /// current Redis server, fallback to regular allocation otherwise.
+    pub fn defrag_alloc<T>(&self, layout: Layout) -> *mut T {
+        unsafe { std::alloc::alloc(layout) }.cast()
+    }
+
+    /// Deallocate memory using defrag deallocator if supported by the
+    /// current Redis server, fallback to regular deallocation otherwise.
+    pub fn defrag_dealloc<T>(&self, ptr: *mut T, layout: Layout) {
+        unsafe { std::alloc::dealloc(ptr.cast(), layout) }
+    }
+
+    /// Defrag a [RedisString]
+    ///
+    /// NOTE: It is only possible to defrag strings that have a single reference.
+    /// Typically this means strings that was copy/cloned using [RedisString::safe_clone]
+    /// or created using [RedisString::new] will not be defrag and will be returned as is.
+    pub fn defrag_redis_string(&self, mut s: RedisString) -> RedisString {
+        let new_inner = unsafe {
+            RedisModule_DefragRedisModuleString
+                .expect("RedisModule_DefragRedisModuleString is NULL")(
+                self.defrag_ctx, s.inner
+            )
+        };
+        if !new_inner.is_null() {
+            s.inner = new_inner;
+        }
+        s
+    }
+}
+
+#[distributed_slice()]
+pub static DEFRAG_FUNCTIONS_LIST: [fn(&DefragContext)] = [..];
+
+#[distributed_slice()]
+pub static DEFRAG_START_FUNCTIONS_LIST: [fn(&DefragContext)] = [..];
+
+#[distributed_slice()]
+pub static DEFRAG_END_FUNCTIONS_LIST: [fn(&DefragContext)] = [..];
+
+extern "C" fn defrag_function(defrag_ctx: *mut raw::RedisModuleDefragCtx) {
+    let mut ctx = DefragContext { defrag_ctx };
+    DEFRAG_FUNCTIONS_LIST.iter().for_each(|callback| {
+        callback(&mut ctx);
+    });
+}
+
+extern "C" fn defrag_start_function(defrag_ctx: *mut raw::RedisModuleDefragCtx) {
+    let mut ctx = DefragContext { defrag_ctx };
+    DEFRAG_START_FUNCTIONS_LIST.iter().for_each(|callback| {
+        callback(&mut ctx);
+    });
+}
+
+extern "C" fn defrag_end_function(defrag_ctx: *mut raw::RedisModuleDefragCtx) {
+    let mut ctx = DefragContext { defrag_ctx };
+    DEFRAG_END_FUNCTIONS_LIST.iter().for_each(|callback| {
+        callback(&mut ctx);
+    });
+}
+
+pub fn register_defrag_functions(ctx: &Context) -> Result<(), RedisError> {
+    let register_defrag_function = match unsafe { raw::RedisModule_RegisterDefragFunc } {
+        Some(f) => f,
+        None => {
+            ctx.log_warning("Skip register defrag function as defrag is not supported on the current Redis server.");
+            return Ok(());
+        }
+    };
+    if !DEFRAG_FUNCTIONS_LIST.is_empty() {
+        let res = unsafe { register_defrag_function(ctx.ctx, Some(defrag_function)) };
+        if res != raw::REDISMODULE_OK as i32 {
+            return Err(RedisError::Str("Failed register defrag function"));
+        }
+    }
+
+    let register_defrag_callbacks = match unsafe { raw::RedisModule_RegisterDefragCallbacks } {
+        Some(f) => f,
+        None => {
+            ctx.log_warning("Skip register defrag callbacks as defrag callbacks is not supported on the current Redis server.");
+            return Ok(());
+        }
+    };
+    if !DEFRAG_START_FUNCTIONS_LIST.is_empty() || !DEFRAG_END_FUNCTIONS_LIST.is_empty() {
+        let res = unsafe {
+            register_defrag_callbacks(
+                ctx.ctx,
+                Some(defrag_start_function),
+                Some(defrag_end_function),
+            )
+        };
+        if res != raw::REDISMODULE_OK as i32 {
+            return Err(RedisError::Str("Failed register defrag callbacks"));
+        }
+    }
+
+    Ok(())
+}

--- a/src/context/defrag.rs
+++ b/src/context/defrag.rs
@@ -45,7 +45,7 @@ impl DefragContext {
     /// so it generally makes sense to do small batches of work in between calls.
     pub fn should_stop(&self) -> bool {
         let should_stop = unsafe {
-            RedisModule_DefragShouldStop.expect("RedisModule_DefragShouldStop is NULL")(
+            RedisModule_DefragShouldStop.expect("RedisModule_DefragShouldStop should be available.")(
                 self.defrag_ctx,
             )
         };
@@ -75,7 +75,7 @@ impl DefragContext {
     /// not be performed.
     pub fn set_cursor(&self, cursor: u64) -> Status {
         unsafe {
-            RedisModule_DefragCursorSet.expect("RedisModule_DefragCursorSet is NULL")(
+            RedisModule_DefragCursorSet.expect("RedisModule_DefragCursorSet should be available.")(
                 self.defrag_ctx,
                 cursor,
             )
@@ -88,7 +88,7 @@ impl DefragContext {
     pub fn get_cursor(&self) -> Result<u64, RedisError> {
         let mut cursor: u64 = 0;
         let res: Status = unsafe {
-            RedisModule_DefragCursorGet.expect("RedisModule_DefragCursorGet is NULL")(
+            RedisModule_DefragCursorGet.expect("RedisModule_DefragCursorGet should be available.")(
                 self.defrag_ctx,
                 (&mut cursor) as *mut u64,
             )
@@ -115,9 +115,9 @@ impl DefragContext {
     /// The function is unsafe because it is assumed that the pointer is valid and previusly
     /// allocated. It is considered undefined if this is not the case.
     pub unsafe fn defrag_realloc<T>(&self, mut ptr: *mut T) -> *mut T {
-        let new_ptr: *mut T = RedisModule_DefragAlloc.expect("RedisModule_DefragAlloc is NULL")(
-            self.defrag_ctx,
-            ptr.cast(),
+        let new_ptr: *mut T = RedisModule_DefragAlloc
+            .expect("RedisModule_DefragAlloc should be available.")(
+            self.defrag_ctx, ptr.cast()
         )
         .cast();
         if !new_ptr.is_null() {
@@ -146,8 +146,9 @@ impl DefragContext {
     pub fn defrag_redis_string(&self, mut s: RedisString) -> RedisString {
         let new_inner = unsafe {
             RedisModule_DefragRedisModuleString
-                .expect("RedisModule_DefragRedisModuleString is NULL")(
-                self.defrag_ctx, s.inner
+                .expect("RedisModule_DefragRedisModuleString should be available.")(
+                self.defrag_ctx,
+                s.inner,
             )
         };
         if !new_inner.is_null() {

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -30,6 +30,7 @@ mod timer;
 pub mod blocked;
 pub mod call_reply;
 pub mod commands;
+pub mod defrag;
 pub mod info;
 pub mod keys_cursor;
 pub mod server_events;
@@ -873,7 +874,7 @@ impl Context {
 }
 
 extern "C" fn post_notification_job_free_callback<F: FnOnce(&Context)>(pd: *mut c_void) {
-    unsafe { Box::from_raw(pd as *mut Option<F>) };
+    drop(unsafe { Box::from_raw(pd as *mut Option<F>) });
 }
 
 extern "C" fn post_notification_job<F: FnOnce(&Context)>(

--- a/src/include/redismodule.h
+++ b/src/include/redismodule.h
@@ -1290,6 +1290,7 @@ REDISMODULE_API int *(*RedisModule_GetCommandKeys)(RedisModuleCtx *ctx, RedisMod
 REDISMODULE_API int *(*RedisModule_GetCommandKeysWithFlags)(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, int *num_keys, int **out_flags) REDISMODULE_ATTR;
 REDISMODULE_API const char *(*RedisModule_GetCurrentCommandName)(RedisModuleCtx *ctx) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_RegisterDefragFunc)(RedisModuleCtx *ctx, RedisModuleDefragFunc func) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_RegisterDefragCallbacks)(RedisModuleCtx *ctx, RedisModuleDefragFunc start, RedisModuleDefragFunc end) REDISMODULE_ATTR;
 REDISMODULE_API void *(*RedisModule_DefragAlloc)(RedisModuleDefragCtx *ctx, void *ptr) REDISMODULE_ATTR;
 REDISMODULE_API RedisModuleString *(*RedisModule_DefragRedisModuleString)(RedisModuleDefragCtx *ctx, RedisModuleString *str) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_DefragShouldStop)(RedisModuleDefragCtx *ctx) REDISMODULE_ATTR;
@@ -1645,6 +1646,7 @@ static void RedisModule_InitAPI(RedisModuleCtx *ctx) {
     REDISMODULE_GET_API(GetCommandKeysWithFlags);
     REDISMODULE_GET_API(GetCurrentCommandName);
     REDISMODULE_GET_API(RegisterDefragFunc);
+    REDISMODULE_GET_API(RegisterDefragCallbacks);
     REDISMODULE_GET_API(DefragAlloc);
     REDISMODULE_GET_API(DefragRedisModuleString);
     REDISMODULE_GET_API(DefragShouldStop);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,7 @@ pub use crate::configuration::EnumConfigurationValue;
 pub use crate::context::call_reply::FutureCallReply;
 pub use crate::context::call_reply::{CallReply, CallResult, ErrorReply, PromiseCallReply};
 pub use crate::context::commands;
+pub use crate::context::defrag;
 pub use crate::context::keys_cursor::KeysCursor;
 pub use crate::context::server_events;
 pub use crate::context::AclPermissions;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -248,6 +248,11 @@ macro_rules! redis_module {
                 return raw::Status::Err as c_int;
             }
 
+            if let Err(e) = $crate::defrag::register_defrag_functions(&context) {
+                context.log_warning(&format!("{e}"));
+                return raw::Status::Err as c_int;
+            }
+
             $(
                 $(
                     $crate::redis_event_handler!(ctx, $(raw::NotifyEvent::$event_type |)+ raw::NotifyEvent::empty(), $event_handler);

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,5 +1,7 @@
+use std::collections::HashMap;
 use std::thread;
 use std::time::Duration;
+use std::time::SystemTime;
 
 use crate::utils::{get_redis_connection, start_redis_server_with_module};
 use anyhow::Context;
@@ -740,6 +742,67 @@ fn test_expire() -> Result<()> {
 
     let ttl: i64 = redis::cmd("ttl").arg(&["key"]).query(&mut con)?;
     assert_eq!(ttl, -1);
+
+    Ok(())
+}
+
+#[test]
+fn test_defrag() -> Result<()> {
+    let port: u16 = 6503;
+    let _guards = vec![start_redis_server_with_module("data_type", port)
+        .with_context(|| "failed to start redis server")?];
+    let mut con =
+        get_redis_connection(port).with_context(|| "failed to connect to redis server")?;
+
+    // Configure active defrag
+    redis::cmd("config")
+        .arg(&["set", "hz", "100"])
+        .query(&mut con)
+        .with_context(|| "failed to run 'config set hz 100'")?;
+
+    redis::cmd("config")
+        .arg(&["set", "active-defrag-ignore-bytes", "1"])
+        .query(&mut con)
+        .with_context(|| "failed to run 'config set active-defrag-ignore-bytes 1'")?;
+
+    redis::cmd("config")
+        .arg(&["set", "active-defrag-threshold-lower", "0"])
+        .query(&mut con)
+        .with_context(|| "failed to run 'config set active-defrag-threshold-lower 0'")?;
+
+    redis::cmd("config")
+        .arg(&["set", "active-defrag-cycle-min", "99"])
+        .query(&mut con)
+        .with_context(|| "failed to run 'config set active-defrag-cycle-min 99'")?;
+
+    // enable active defrag
+    if let Err(_) = redis::cmd("config")
+        .arg(&["set", "activedefrag", "yes"])
+        .query::<String>(&mut con)
+    {
+        // Server the does not support active defrag, avoid failing the test.
+        return Ok(());
+    }
+
+    let start = SystemTime::now();
+    loop {
+        let res: HashMap<String, usize> = redis::cmd("alloc.defragstats")
+            .query(&mut con)
+            .with_context(|| "failed to run 'config set active-defrag-cycle-min 99'")?;
+        let num_defrag_globals = res.get("num_defrag_globals").ok_or_else(|| {
+            anyhow::Error::msg("Failed getting 'num_defrag_globals' value from result")
+        })?;
+        // Wait till we will get at least 2 defrag cycles.
+        // We are looking at num_defrag_globals because this is supported by all Redis versions
+        // that supports defrag.
+        if *num_defrag_globals > 2 {
+            break;
+        }
+        let duration = SystemTime::now().duration_since(start)?;
+        if duration > Duration::from_secs(30) {
+            return Err(anyhow::Error::msg("Failed waiting for defrag cycle"));
+        }
+    }
 
     Ok(())
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -776,9 +776,10 @@ fn test_defrag() -> Result<()> {
         .with_context(|| "failed to run 'config set active-defrag-cycle-min 99'")?;
 
     // enable active defrag
-    if let Err(_) = redis::cmd("config")
+    if redis::cmd("config")
         .arg(&["set", "activedefrag", "yes"])
         .query::<String>(&mut con)
+        .is_err()
     {
         // Server the does not support active defrag, avoid failing the test.
         return Ok(());


### PR DESCRIPTION
The PR adds support for defrag API.
The PR introduce a new struct, `DefragContext`, which provide a safe API over `*mut raw::RedisModuleDefragCtx`.

**Notice** that we do expose an unsafe API to create `DefragContext` from `*mut raw::RedisModuleDefragCtx`. This is because we do not have a safe API for datatype registration. User must register an unsafe function as the defrag callback of the datatype and create the `DefragContext` from `*mut raw::RedisModuleDefragCtx`. We should consider adding a safe API for datatype creation.

In addition, the PR introduce 3 new proc macros:

* defrag_function - allows to register a function to defrag global data
* defrag_start_function - allows to register a function to defrag global data when defrag cycle starts.
* defrag_end_function - allows to register a function to defrag global data when defrag cycle ends.

Example and test for the new API were added.

**Notice**: The start and the end callbacks for defrag was added on [this](https://github.com/redis/redis/pull/13509) PR