### PR TITLE
Update crates io publish action

### DIFF
--- a/.github/workflows/cratesio-publish.yml
+++ b/.github/workflows/cratesio-publish.yml
@@ -8,42 +8,39 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
           override: true
 
-      - name: get version from tag
+      - name: Get version from tag
         id: get_version
-        run: |
-            realversion="${GITHUB_REF/refs\/tags\//}"
-            realversion="${realversion//v/}"
-            echo "::set-output name=VERSION::$realversion"
+        uses: jannemattila/get-version-from-tag@v4
 
       - name: Set the version for publishing
-        uses: ciiiii/toml-editor@1.0.0
+        uses: colathro/toml-editor@1.1.0
         with:
           file: "Cargo.toml"
           key: "package.version"
-          value: "${{ steps.get_version.outputs.VERSION }}"
+          value: "${{ steps.get_version.outputs.version }}"
 
       - name: Set the version for redismodule-rs-macros-internals
-        uses: ciiiii/toml-editor@1.0.0
+        uses: colathro/toml-editor@1.1.0
         with:
           file: "Cargo.toml"
           key: "dependencies.redis-module-macros-internals"
           value: "${{ steps.get_version.outputs.VERSION }}"
 
       - name: Set the version for publishing on macros crate
-        uses: ciiiii/toml-editor@1.0.0
+        uses: colathro/toml-editor@1.1.0
         with:
           file: "redismodule-rs-macros/Cargo.toml"
           key: "package.version"
           value: "${{ steps.get_version.outputs.VERSION }}"
       
       - name: Set the version for publishing on internal macros crate
-        uses: ciiiii/toml-editor@1.0.0
+        uses: colathro/toml-editor@1.1.0
         with:
           file: "redismodule-rs-macros-internals/Cargo.toml"
           key: "package.version"


### PR DESCRIPTION
Fixes #401. Obviously not fully tested since I can't run the publish. This switches out `ciiiii/toml-editor@1.0.0` for `colathro/toml-editor@1.1.0` which appears to work (has the same interface) and updates `actions/checkout` to v4.