### PR TITLE
Disable default features on nix crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,7 +130,7 @@ strum_macros = "0.24"
 backtrace = "0.3"
 linkme = "0.3"
 serde = { version = "1", features = ["derive"] }
-nix = "0.26"
+nix = { version = "0.26", default-features = false }
 cfg-if = "1"
 redis-module-macros-internals = { path = "./redismodule-rs-macros-internals" }
 log = "0.4"


### PR DESCRIPTION
This PR disables the default features on the `nix` crate. Enabling default features makes `nix`, and therefore anything using `redis-module`, require at least `glibc >= 2.27` as it'll contain a reference to e.g. `memfd_create`. For instance, Amazon Linux 2 ships with `glibc 2.26` and does not work with default features enabled.

No features are actually enabled by `redis-module`.