### PR TITLE
README: update Redis Modules API link

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ It allows writing Redis modules in Rust, without needing to use raw pointers or 
 See the [examples](examples) directory for some sample modules.
 
 This crate tries to provide high-level wrappers around the standard Redis Modules API, while preserving the API's basic concepts.
-Therefore, following the [Redis Modules API](https://redis.io/topics/modules-intro) documentation will be mostly relevant here as well.
+Therefore, following the [Redis Modules API](https://redis.io/docs/latest/develop/reference/modules/) documentation will be mostly relevant here as well.
 
 # Redis Modules based on this crate
 


### PR DESCRIPTION
The old one was no longer working.