### PR TITLE
Fix CI runs: Use one of the two exclusive bindgen features in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,16 +86,16 @@ jobs:
         run: cargo fmt --all -- --check
 
       - name: Clippy
-        run: cargo clippy --all-targets --no-default-features --features min-redis-compatibility-version-${{ matrix.redis-version[0] }}
+        run: cargo clippy --all-targets --no-default-features --features "bindgen/runtime min-redis-compatibility-version-${{ matrix.redis-version[0] }}"
 
       - name: Build debug
-        run: cargo build --no-default-features --features min-redis-compatibility-version-${{ matrix.redis-version[0] }}
+        run: cargo build --no-default-features --features "bindgen/runtime min-redis-compatibility-version-${{ matrix.redis-version[0] }}"
 
       - name: Build release
-        run: cargo build --release --no-default-features --features min-redis-compatibility-version-${{ matrix.redis-version[0] }}
+        run: cargo build --release --no-default-features --features "bindgen/runtime min-redis-compatibility-version-${{ matrix.redis-version[0] }}"
 
       - name: Test
-        run: cargo test --no-default-features --features min-redis-compatibility-version-${{ matrix.redis-version[0] }}
+        run: cargo test --no-default-features --features "bindgen/runtime min-redis-compatibility-version-${{ matrix.redis-version[0] }}"
 
       - name: Doc
-        run: cargo doc --all-features
+        run: cargo doc --no-default-features --features "all-features-but-xor bindgen/runtime min-redis-compatibility-version-${{ matrix.redis-version[0] }}"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,6 +148,8 @@ cc = "1"
 
 [features]
 default = ["min-redis-compatibility-version-6-0", "bindgen-runtime"]
+
+# xor having minimum compatibility version
 min-redis-compatibility-version-7-4 = ["redis-module/min-redis-compatibility-version-7-4"]
 min-redis-compatibility-version-7-2 = ["redis-module/min-redis-compatibility-version-7-2"]
 min-redis-compatibility-version-7-0 = ["redis-module/min-redis-compatibility-version-7-0"]
@@ -158,3 +160,6 @@ min-redis-compatibility-version-6-0 = ["redis-module/min-redis-compatibility-ver
 bindgen-static = ["bindgen/static"]
 # Enable dynamic linking to libclang in bindgen
 bindgen-runtime = ["bindgen/runtime"]
+
+# List all features here, that are not in a exclusive or relationship
+all-features-but-xor = []


### PR DESCRIPTION
Use `bindgen/runtime` feature which is one of the two exclusive bindgen features in cargo.toml
Ensure that features that are `xor` are not used together in the github workflows.