### PR TITLE
MOD-11364: Improves the robustness of integration tests

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -651,11 +651,7 @@ fn test_open_key_with_flags() -> Result<()> {
 
 #[test]
 fn test_expire() -> Result<()> {
-    let port: u16 = 6502;
-    let _guards = vec![start_redis_server_with_module("expire", port)
-        .with_context(|| "failed to start redis server")?];
-    let mut con =
-        get_redis_connection(port).with_context(|| "failed to connect to redis server")?;
+    let mut con = TestConnection::new("expire");
 
     // Create a key without TTL
     redis::cmd("set")
@@ -689,11 +685,7 @@ fn test_expire() -> Result<()> {
 
 #[test]
 fn test_defrag() -> Result<()> {
-    let port: u16 = 6503;
-    let _guards = vec![start_redis_server_with_module("data_type", port)
-        .with_context(|| "failed to start redis server")?];
-    let mut con =
-        get_redis_connection(port).with_context(|| "failed to connect to redis server")?;
+    let mut con = TestConnection::new("data_type");
 
     // Configure active defrag
     redis::cmd("config")

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -96,11 +96,15 @@ pub fn start_redis_server_with_module(module_name: &str, port: u16) -> Result<Ch
     let module_path = format!("{}", module_path.display());
 
     let rdb_filename = format!("test-on-port-{}.rdb", port);
-    let rdb_out_dir = std::env::current_dir().unwrap();
+    let rdb_out_dir = std::env::current_dir()?;
     let rdb_out_dir = rdb_out_dir.join(format!("target/integration-test/instance-p{}", port));
     if rdb_out_dir.exists() {
-        fs::remove_dir_all(&rdb_out_dir)
-            .with_context(|| format!("Removing existing rdb file: {}", rdb_out_dir.display()))?;
+        fs::remove_dir_all(&rdb_out_dir).with_context(|| {
+            format!(
+                "Removing existing rdb output dir: {}",
+                rdb_out_dir.display()
+            )
+        })?;
     }
 
     fs::create_dir_all(&rdb_out_dir)
@@ -114,7 +118,9 @@ pub fn start_redis_server_with_module(module_name: &str, port: u16) -> Result<Ch
         "--enable-debug-command",
         "yes",
         "--dir",
-        rdb_out_dir.to_str().unwrap(),
+        rdb_out_dir
+            .to_str()
+            .expect("RDB output directory path contains invalid UTF-8 characters"),
         "--dbfilename",
         rdb_filename.as_str(),
     ];


### PR DESCRIPTION
Prior:
The integration tests were flaky. They failed for non-obvious reasons, which were related to side effects.

Changes:
- We removed the manual assigned port numbers in two integration tests. That ensures that each integration Test uses it's own Redis Server instance
- We used a separate output directory and filename for the rdb file that may get stored during integration testing.

Result:
The CI in the stacked PR - https://github.com/RedisLabsModules/redismodule-rs/pull/419 - has been completed successfully.