### PR TITLE
Replace doc /// comment into regular comment // inside macro.

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -167,9 +167,9 @@ macro_rules! redis_module {
     (
         name: $module_name:expr,
         version: $module_version:expr,
-        /// Global allocator for the redis module defined.
-        /// In most of the cases, the Redis allocator ([crate::alloc::RedisAlloc])
-        /// should be used.
+        // Global allocator for the redis module defined.
+        // In most of the cases, the Redis allocator ([crate::alloc::RedisAlloc])
+        // should be used.
         allocator: ($allocator_type:ty, $allocator_init:expr),
         data_types: [
             $($data_type:ident),* $(,)*


### PR DESCRIPTION
https://github.com/RedisLabsModules/redismodule-rs/issues/416


Since /#[doc = "..."] outer attribute is not valid for macro expansion. Recommendation to follow Rust conventions.

[Official documentation. 
Attributes section:](https://doc.rust-lang.org/reference/attributes.html) 
Quote:

> Attributes may be applied to many things in the language:
> 
> All [item declarations](https://doc.rust-lang.org/reference/items.html) accept outer attributes while [external blocks](https://doc.rust-lang.org/reference/items/external-blocks.html), [functions](https://doc.rust-lang.org/reference/items/functions.html), [implementations](https://doc.rust-lang.org/reference/items/implementations.html), and [modules](https://doc.rust-lang.org/reference/items/modules.html) accept inner attributes.
> Most [statements](https://doc.rust-lang.org/reference/statements.html) accept outer attributes (see [Expression Attributes](https://doc.rust-lang.org/reference/expressions.html#expression-attributes) for limitations on expression statements).
> [Block expressions](https://doc.rust-lang.org/reference/expressions/block-expr.html) accept outer and inner attributes, but only when they are the outer expression of an [expression statement](https://doc.rust-lang.org/reference/statements.html#expression-statements) or the final expression of another block expression.
> [Enum](https://doc.rust-lang.org/reference/items/enumerations.html) variants and [struct](https://doc.rust-lang.org/reference/items/structs.html) and [union](https://doc.rust-lang.org/reference/items/unions.html) fields accept outer attributes.
> [Match expression arms](https://doc.rust-lang.org/reference/expressions/match-expr.html) accept outer attributes.
> [Generic lifetime or type parameter](https://doc.rust-lang.org/reference/items/generics.html) accept outer attributes.
> Expressions accept outer attributes in limited situations, see [Expression Attributes](https://doc.rust-lang.org/reference/expressions.html#expression-attributes) for details.
> [Function](https://doc.rust-lang.org/reference/items/functions.html), [closure](https://doc.rust-lang.org/reference/expressions/closure-expr.html) and [function pointer](https://doc.rust-lang.org/reference/types/function-pointer.html) parameters accept outer attributes. This includes attributes on variadic parameters denoted with ... in function pointers and [external blocks](https://doc.rust-lang.org/reference/items/external-blocks.html#variadic-functions).
