### PR TITLE
fix edition

### DIFF
--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "common"
 version = "0.1.0"
-edition = "2024"
+edition = "2021"
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Set Rust edition in `common/Cargo.toml` from `2024` to `2021`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dccc0a3a17242a9e1abadc62b8faa0c632cd807c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->