### PR TITLE
fix: add `to_raw_parts` method & fix unsoundness bug

### DIFF
--- a/examples/scan_keys.rs
+++ b/examples/scan_keys.rs
@@ -17,8 +17,8 @@ fn scan_keys(ctx: &Context, _args: Vec<RedisString>) -> RedisResult {
     let cursor = KeysCursor::new();
     let mut res = Vec::new();
 
-    let scan_callback = |_ctx: &Context, key_name: RedisString, _key: Option<&RedisKey>| {
-        res.push(RedisValue::BulkRedisString(key_name));
+    let scan_callback = |ctx: &Context, key_name: &RedisString, _key: Option<&RedisKey>| {
+        res.push(RedisValue::BulkRedisString(key_name.safe_clone(ctx)));
     };
 
     while cursor.scan(ctx, &scan_callback) {


### PR DESCRIPTION
This change introduces the `RedisKey::to_raw_parts` method as a counterpart to `RedisKey::from_raw_parts`. We need to be able to access the inner pointer for more low-level operations. It also marks `from_raw_parts` as unsafe adding documentation to both.

Additionally this fixes an unsoundness bug in in `KeyCursor` that was leading to possible use-after free of the key name provided to the scan callback.
