### PR TITLE
Add Rust bindings for Redis Module Command Filter APIs (#3)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,6 +120,10 @@ crate-type = ["cdylib"]
 name = "expire"
 crate-type = ["cdylib"]
 
+[[example]]
+name = "command_filter"
+crate-type = ["cdylib"]
+
 [dependencies]
 bitflags = "2"
 libc = "0.2"

--- a/examples/command_filter.rs
+++ b/examples/command_filter.rs
@@ -1,0 +1,123 @@
+use redis_module::{
+    raw, redis_module, CommandFilter, CommandFilterContext, Context, NextArg, RedisError,
+    RedisResult, RedisString, RedisValue,
+};
+use std::sync::atomic::{AtomicPtr, Ordering};
+
+static COMMAND_FILTER: AtomicPtr<raw::RedisModuleCommandFilter> =
+    AtomicPtr::new(std::ptr::null_mut());
+
+extern "C" fn command_filter_callback(fctx: *mut raw::RedisModuleCommandFilterCtx) {
+    let filter_ctx = CommandFilterContext::new(fctx);
+    command_filter_impl(&filter_ctx);
+}
+
+fn command_filter_impl(fctx: &CommandFilterContext) {
+    // Get the command name
+    if let Ok(cmd_str) = fctx.cmd_get_try_as_str() {
+        // Example: Log all SET commands
+        if cmd_str.eq_ignore_ascii_case("set") {
+            // You can inspect or modify arguments here
+            // For example, you could replace sensitive data
+
+            // Get all arguments (excluding command)
+            let args = fctx.get_all_args_wo_cmd();
+            let _num_args = args.len();
+
+            // Note: In a real implementation, you would use the Context
+            // to log, but we don't have access to it in the filter callback
+
+            #[cfg(any(
+                feature = "min-redis-compatibility-version-7-4",
+                feature = "min-redis-compatibility-version-7-2"
+            ))]
+            {
+                let _client_id = fctx.get_client_id();
+            }
+        }
+    }
+}
+
+fn filter_register(ctx: &Context, _args: Vec<RedisString>) -> RedisResult {
+    let current = COMMAND_FILTER.load(Ordering::Acquire);
+
+    if !current.is_null() {
+        return Err(RedisError::String("Filter already registered".to_string()));
+    }
+
+    let filter = ctx.register_command_filter(command_filter_callback, 0);
+    COMMAND_FILTER.store(filter.as_ptr(), Ordering::Release);
+
+    Ok(RedisValue::SimpleStringStatic("OK"))
+}
+
+fn filter_unregister(ctx: &Context, _args: Vec<RedisString>) -> RedisResult {
+    let filter_ptr = COMMAND_FILTER.swap(std::ptr::null_mut(), Ordering::AcqRel);
+
+    if !filter_ptr.is_null() {
+        let filter = CommandFilter::new(filter_ptr);
+        ctx.unregister_command_filter(&filter);
+        Ok(RedisValue::SimpleStringStatic("OK"))
+    } else {
+        Err(RedisError::String("No filter registered".to_string()))
+    }
+}
+
+fn filter_test_args(ctx: &Context, args: Vec<RedisString>) -> RedisResult {
+    let mut args_iter = args.into_iter().skip(1);
+    let key = args_iter.next_arg()?;
+    let value = args_iter.next_arg()?;
+
+    // This SET command will be intercepted by the filter if it's registered
+    ctx.call("SET", &[&key, &value])?;
+
+    Ok(RedisValue::SimpleStringStatic("OK"))
+}
+
+fn filter_modify_example(ctx: &Context, args: Vec<RedisString>) -> RedisResult {
+    // This example demonstrates how to modify command arguments in a filter
+    // In this case, we'll register a temporary filter that adds a prefix to SET keys
+
+    extern "C" fn modify_filter(fctx: *mut raw::RedisModuleCommandFilterCtx) {
+        let filter_ctx = CommandFilterContext::new(fctx);
+
+        // Check if this is a SET command
+        if let Ok(cmd) = filter_ctx.cmd_get_try_as_str() {
+            if cmd.eq_ignore_ascii_case("set") && filter_ctx.args_count() >= 2 {
+                // Get the current key
+                if let Ok(key) = filter_ctx.arg_get_try_as_str(1) {
+                    // Replace it with a prefixed version
+                    let new_key = format!("filtered:{}", key);
+                    filter_ctx.arg_replace(1, &new_key);
+                }
+            }
+        }
+    }
+
+    let filter = ctx.register_command_filter(modify_filter, 0);
+
+    // Execute a SET command which will be modified by the filter
+    if args.len() > 2 {
+        let _ = ctx.call("SET", &[&args[1], &args[2]]);
+    }
+
+    // Unregister the filter
+    ctx.unregister_command_filter(&filter);
+
+    Ok(RedisValue::SimpleStringStatic("OK"))
+}
+
+//////////////////////////////////////////////////////
+
+redis_module! {
+    name: "command_filter",
+    version: 1,
+    allocator: (redis_module::alloc::RedisAlloc, redis_module::alloc::RedisAlloc),
+    data_types: [],
+    commands: [
+        ["filter.register", filter_register, "", 0, 0, 0, ""],
+        ["filter.unregister", filter_unregister, "", 0, 0, 0, ""],
+        ["filter.test_args", filter_test_args, "", 0, 0, 0, ""],
+        ["filter.modify_example", filter_modify_example, "", 0, 0, 0, ""],
+    ],
+}

--- a/src/context/command_filter.rs
+++ b/src/context/command_filter.rs
@@ -1,0 +1,234 @@
+use std::os::raw::c_int;
+use std::str::Utf8Error;
+
+use crate::raw;
+use crate::{Context, RedisString};
+
+/// A wrapper around the Redis Module Command Filter pointer.
+///
+/// This provides a type-safe way to work with command filter handles.
+#[derive(Debug, Clone, Copy)]
+pub struct CommandFilter {
+    pub(crate) inner: *mut raw::RedisModuleCommandFilter,
+}
+
+// Required for thread-safe storage of command filters
+unsafe impl Send for CommandFilter {}
+unsafe impl Sync for CommandFilter {}
+
+impl CommandFilter {
+    /// Create a new CommandFilter from a raw pointer.
+    pub fn new(inner: *mut raw::RedisModuleCommandFilter) -> Self {
+        CommandFilter { inner }
+    }
+
+    /// Check if the filter pointer is null.
+    pub fn is_null(&self) -> bool {
+        self.inner.is_null()
+    }
+
+    /// Get the raw pointer to the filter.
+    ///
+    /// This is useful when you need to store the filter handle and later
+    /// recreate the CommandFilter wrapper.
+    pub fn as_ptr(&self) -> *mut raw::RedisModuleCommandFilter {
+        self.inner
+    }
+}
+
+/// A wrapper around the Redis Module Command Filter Context.
+///
+/// This context is passed to command filter callbacks and provides methods
+/// to inspect and modify command arguments.
+pub struct CommandFilterContext {
+    inner: *mut raw::RedisModuleCommandFilterCtx,
+}
+
+impl CommandFilterContext {
+    /// Create a new CommandFilterContext from a raw pointer.
+    ///
+    /// # Safety
+    /// The caller must ensure that the pointer is valid and only used within
+    /// the lifetime of the command filter callback.
+    pub fn new(inner: *mut raw::RedisModuleCommandFilterCtx) -> Self {
+        CommandFilterContext { inner }
+    }
+
+    /// Get the number of arguments in the filtered command.
+    ///
+    /// Wrapper for `RedisModule_CommandFilterArgsCount`.
+    pub fn args_count(&self) -> c_int {
+        unsafe { raw::RedisModule_CommandFilterArgsCount.unwrap()(self.inner) }
+    }
+
+    /// Get the argument at the specified position as a raw pointer.
+    ///
+    /// Wrapper for `RedisModule_CommandFilterArgGet`.
+    ///
+    /// # Arguments
+    /// * `pos` - The position of the argument (0-based)
+    ///
+    /// # Returns
+    /// A pointer to the RedisModuleString, or null if the position is out of bounds.
+    pub fn arg_get(&self, pos: c_int) -> *mut raw::RedisModuleString {
+        unsafe { raw::RedisModule_CommandFilterArgGet.unwrap()(self.inner, pos) }
+    }
+
+    /// Get the argument at the specified position as a string slice.
+    ///
+    /// Wrapper for `RedisModule_CommandFilterArgGet` with automatic conversion to `&str`.
+    ///
+    /// # Arguments
+    /// * `pos` - The position of the argument (0-based)
+    ///
+    /// # Returns
+    /// The argument as a string slice, or an error if the position is out of bounds
+    /// or the argument is not valid UTF-8.
+    pub fn arg_get_try_as_str(&self, pos: c_int) -> Result<&str, Utf8Error> {
+        let arg = self.arg_get(pos);
+        RedisString::from_ptr(arg)
+    }
+
+    /// Get the command name (the 0th argument) as a string slice.
+    ///
+    /// This is a convenience wrapper that always fetches argument 0, which is
+    /// the command name.
+    ///
+    /// # Returns
+    /// The command name as a string slice, or an error if not valid UTF-8.
+    pub fn cmd_get_try_as_str(&self) -> Result<&str, Utf8Error> {
+        self.arg_get_try_as_str(0)
+    }
+
+    /// Get all arguments except the command name.
+    ///
+    /// This is a convenience method that returns a vector of all arguments
+    /// starting from position 1 (skipping the command name at position 0).
+    ///
+    /// # Returns
+    /// A vector of string slices containing all arguments. Invalid UTF-8 arguments are skipped.
+    pub fn get_all_args_wo_cmd(&self) -> Vec<&str> {
+        let mut output = Vec::new();
+        for pos in 1..self.args_count() {
+            if let Ok(arg) = self.arg_get_try_as_str(pos) {
+                output.push(arg);
+            }
+        }
+        output
+    }
+
+    /// Replace the argument at the specified position.
+    ///
+    /// Wrapper for `RedisModule_CommandFilterArgReplace`.
+    ///
+    /// # Arguments
+    /// * `pos` - The position of the argument to replace (0-based)
+    /// * `arg` - The new argument value as a string slice
+    pub fn arg_replace(&self, pos: c_int, arg: &str) {
+        unsafe {
+            let new_arg = RedisString::create(None, arg);
+            raw::string_retain_string(std::ptr::null_mut(), new_arg.inner);
+            raw::RedisModule_CommandFilterArgReplace.unwrap()(self.inner, pos, new_arg.inner)
+        };
+    }
+
+    /// Insert an argument at the specified position.
+    ///
+    /// Wrapper for `RedisModule_CommandFilterArgInsert`.
+    ///
+    /// # Arguments
+    /// * `pos` - The position where the argument should be inserted (0-based)
+    /// * `arg` - The argument to insert as a string slice
+    pub fn arg_insert(&self, pos: c_int, arg: &str) {
+        unsafe {
+            let new_arg = RedisString::create(None, arg);
+            raw::string_retain_string(std::ptr::null_mut(), new_arg.inner);
+            raw::RedisModule_CommandFilterArgInsert.unwrap()(self.inner, pos, new_arg.inner)
+        };
+    }
+
+    /// Delete the argument at the specified position.
+    ///
+    /// Wrapper for `RedisModule_CommandFilterArgDelete`.
+    ///
+    /// # Arguments
+    /// * `pos` - The position of the argument to delete (0-based)
+    pub fn arg_delete(&self, pos: c_int) {
+        unsafe { raw::RedisModule_CommandFilterArgDelete.unwrap()(self.inner, pos) };
+    }
+
+    /// Get the client ID of the client that issued the filtered command.
+    ///
+    /// Wrapper for `RedisModule_CommandFilterGetClientId`.
+    ///
+    /// # Returns
+    /// The client ID as an unsigned 64-bit integer.
+    ///
+    /// # Note
+    /// This API is not supported in Redis 7.0. It requires Redis 7.2 or later.
+    #[cfg(any(
+        feature = "min-redis-compatibility-version-7-4",
+        feature = "min-redis-compatibility-version-7-2"
+    ))]
+    pub fn get_client_id(&self) -> u64 {
+        unsafe { raw::RedisModule_CommandFilterGetClientId.unwrap()(self.inner) }
+    }
+}
+
+impl Context {
+    /// Register a command filter callback.
+    ///
+    /// Wrapper for `RedisModule_RegisterCommandFilter`.
+    ///
+    /// The callback will be invoked for each command executed. The callback
+    /// should be an `extern "C"` function that accepts a command filter context.
+    ///
+    /// # Arguments
+    /// * `callback` - The callback function to be invoked for each command
+    /// * `flags` - Flags for the command filter (currently unused, pass 0)
+    ///
+    /// # Returns
+    /// A CommandFilter handle that can be used to unregister the filter later.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use redis_module::{Context, RedisResult};
+    /// # use redis_module::CommandFilterContext;
+    /// extern "C" fn my_filter(fctx: *mut redis_module::raw::RedisModuleCommandFilterCtx) {
+    ///     let filter_ctx = CommandFilterContext::new(fctx);
+    ///     // Filter logic here
+    /// }
+    ///
+    /// fn init(ctx: &Context) -> RedisResult {
+    ///     let filter = ctx.register_command_filter(my_filter, 0);
+    ///     // Store filter for later unregistration if needed
+    ///     Ok(().into())
+    /// }
+    /// ```
+    pub fn register_command_filter(
+        &self,
+        callback: extern "C" fn(*mut raw::RedisModuleCommandFilterCtx),
+        flags: u32,
+    ) -> CommandFilter {
+        let filter_ptr = unsafe {
+            raw::RedisModule_RegisterCommandFilter.unwrap()(
+                self.ctx,
+                Some(callback),
+                flags as c_int,
+            )
+        };
+        CommandFilter::new(filter_ptr)
+    }
+
+    /// Unregister a previously registered command filter.
+    ///
+    /// Wrapper for `RedisModule_UnregisterCommandFilter`.
+    ///
+    /// # Arguments
+    /// * `filter` - The filter handle returned by `register_command_filter`
+    pub fn unregister_command_filter(&self, filter: &CommandFilter) {
+        unsafe {
+            raw::RedisModule_UnregisterCommandFilter.unwrap()(self.ctx, filter.inner);
+        }
+    }
+}

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -29,6 +29,7 @@ mod timer;
 
 pub mod blocked;
 pub mod call_reply;
+pub mod command_filter;
 pub mod commands;
 pub mod defrag;
 pub mod info;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@ mod macros;
 mod utils;
 
 pub use crate::context::blocked::BlockedClient;
+pub use crate::context::command_filter::{CommandFilter, CommandFilterContext};
 pub use crate::context::thread_safe::{
     ContextGuard, DetachedFromClient, RedisGILGuard, RedisLockIndicator, ThreadSafeContext,
 };


### PR DESCRIPTION
* Initial plan

* Add Command Filter API support

- Created command_filter.rs module with CommandFilterContext
- Implemented all 8 Redis Command Filter C APIs
- Added register/unregister command filter methods to Context
- Created command_filter example demonstrating usage