### PR TITLE
Rename 'common' to 'redis-module-common'

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -142,7 +142,7 @@ nix = { version = "0.26", default-features = false }
 cfg-if = "1"
 redis-module-macros-internals = { path = "./redismodule-rs-macros-internals" }
 log = "0.4"
-common = { path = "./common" }
+common = { path = "./common", package = "redis-module-common" }
 
 [dev-dependencies]
 anyhow = "1"

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "common"
+name = "redis-module-common"
 version = "0.1.0"
 edition = "2021"
 license = "BSD-3-Clause"

--- a/redismodule-rs-macros/Cargo.toml
+++ b/redismodule-rs-macros/Cargo.toml
@@ -17,7 +17,7 @@ quote = "1.0"
 proc-macro2 = "1"
 serde = { version = "1", features = ["derive"] }
 serde_syn = "0.1.0"
-common = { path = "../common" }
+common = { path = "../common", package = "redis-module-common" }
 
 [lib]
 proc-macro = true


### PR DESCRIPTION
Avoid naming issues when publishing to crates.io.