### PR TITLE
chore: Fill in missing fields in Cargo.toml for redis-module-common.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,16 +5,17 @@ members = [".", "redismodule-rs-macros", "redismodule-rs-macros-internals"]
 version = "2.0.8"
 license = "BSD-3-Clause"
 edition = "2021"
+repository = "https://github.com/RedisLabsModules/redismodule-rs"
 
 [package]
 name = "redis-module"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
 authors = ["Gavrie Philipson <gavrie@redis.com>", "Guy Korland <guy.korland@redis.com>"]
 build = "build.rs"
 description = "A toolkit for building Redis modules in Rust"
-repository = "https://github.com/RedisLabsModules/redismodule-rs"
 readme = "README.md"
 keywords = ["redis", "plugin"]
 categories = ["database", "api-bindings"]

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -1,8 +1,11 @@
 [package]
 name = "redis-module-common"
 version = "0.1.1"
-edition = "2021"
-license = "BSD-3-Clause"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Internal utility library shared by the user-facing redis-module-* crates"
+keywords = ["redis", "plugin"]
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }

--- a/redismodule-rs-macros-internals/Cargo.toml
+++ b/redismodule-rs-macros-internals/Cargo.toml
@@ -5,7 +5,7 @@ description = "A macros crate for redismodule-rs"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
-repository = "https://github.com/RedisLabsModules/redismodule-rs"
+repository.workspace = true
 keywords = ["redis", "plugin"]
 categories = ["database", "api-bindings"]
 

--- a/redismodule-rs-macros/Cargo.toml
+++ b/redismodule-rs-macros/Cargo.toml
@@ -3,9 +3,9 @@ name = "redis-module-macros"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
 authors = ["Meir Shpilraien <meir@redis.com>"]
 description = "A macros crate for redismodule-rs"
-repository = "https://github.com/RedisLabsModules/redismodule-rs"
 keywords = ["redis", "plugin"]
 categories = ["database", "api-bindings"]
 


### PR DESCRIPTION
Share repository field across workspace crates.