### PR TITLE
chore: Ensure all local path dependencies specify the corresponding crates.io version for publishing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,16 +141,16 @@ linkme = "0.3"
 serde = { version = "1", features = ["derive"] }
 nix = { version = "0.26", default-features = false }
 cfg-if = "1"
-redis-module-macros-internals = { path = "./redismodule-rs-macros-internals" }
+redis-module-macros-internals = { path = "./redismodule-rs-macros-internals", version = "2.0.8" }
 log = "0.4"
-common = { path = "./common", package = "redis-module-common" }
+common = { path = "./common", package = "redis-module-common", version = "0.1.1" }
 
 [dev-dependencies]
 anyhow = "1"
 redis = "0.23"
 lazy_static = "1"
-redis-module-macros = { path = "./redismodule-rs-macros"}
-redis-module = { path = "./", default-features = false }
+redis-module-macros = { path = "./redismodule-rs-macros", version = "2.0.8" }
+redis-module = { path = "./", default-features = false, version = "2.0.8" }
 
 [build-dependencies]
 bindgen = { version = "0.72.1", default-features = false, features = ["logging", "prettyplease"]}

--- a/redismodule-rs-macros/Cargo.toml
+++ b/redismodule-rs-macros/Cargo.toml
@@ -17,7 +17,7 @@ quote = "1.0"
 proc-macro2 = "1"
 serde = { version = "1", features = ["derive"] }
 serde_syn = "0.1.0"
-common = { path = "../common", package = "redis-module-common" }
+common = { path = "../common", package = "redis-module-common", version = "0.1.1" }
 
 [lib]
 proc-macro = true


### PR DESCRIPTION
Solves the error in https://github.com/RedisLabsModules/redismodule-rs/actions/runs/25370768660/job/74393398416.