### PR TITLE
chore: Don't fill in crates.io version for dev-dependencies entries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -149,8 +149,8 @@ common = { path = "./common", package = "redis-module-common", version = "0.1.1"
 anyhow = "1"
 redis = "0.23"
 lazy_static = "1"
-redis-module-macros = { path = "./redismodule-rs-macros", version = "2.0.8" }
-redis-module = { path = "./", default-features = false, version = "2.0.8" }
+redis-module-macros = { path = "./redismodule-rs-macros" }
+redis-module = { path = "./", default-features = false }
 
 [build-dependencies]
 bindgen = { version = "0.72.1", default-features = false, features = ["logging", "prettyplease"]}


### PR DESCRIPTION
Otherwise, cargo chokes when publishing ([here](https://github.com/RedisLabsModules/redismodule-rs/actions/runs/25374458621/job/74405889889)), claiming that the very same version it is trying to publish doesn't exist on the registry (who would have guessed).