### PR TITLE
chore: bump workspace version to 2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Other
 
 - Skip versions 2.1.0 through 2.1.3. These exist as git tags on the `2.1` branch and were not published to crates.io. All changes from that branch are included in this release.
+- Add release-plz configuration: `redis-module` releases are tagged and named `v<version>`, matching the existing tag format, and marked as the latest GitHub release.
 
 ## [2.0.8](https://github.com/RedisLabsModules/redismodule-rs/compare/redis-module-v2.0.7...redis-module-v2.0.8) - 2026-05-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.0](https://github.com/RedisLabsModules/redismodule-rs/compare/redis-module-v2.0.8...redis-module-v2.2.0) - 2026-07-09
+
+### Added
+
+- Add `KeyFlags::ACCESS_TRIMMED` flag.
+
+### Changed
+
+- `RedisKey::hash_get` accepts any `impl AsRef<[u8]>` as the field argument instead of only `&str` (MOD-16165).
+
+### Other
+
+- Skip versions 2.1.0 through 2.1.3. These exist as git tags on the `2.1` branch and were not published to crates.io. All changes from that branch are included in this release.
+
 ## [2.0.8](https://github.com/RedisLabsModules/redismodule-rs/compare/redis-module-v2.0.7...redis-module-v2.0.8) - 2026-05-04
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "redismodule-rs-macros", "redismodule-rs-macros-internals"]
 
 [workspace.package]
-version = "2.0.8"
+version = "2.2.0"
 license = "BSD-3-Clause"
 edition = "2021"
 repository = "https://github.com/RedisLabsModules/redismodule-rs"
@@ -141,7 +141,7 @@ linkme = "0.3"
 serde = { version = "1", features = ["derive"] }
 nix = { version = "0.26", default-features = false }
 cfg-if = "1"
-redis-module-macros-internals = { path = "./redismodule-rs-macros-internals", version = "2.0.8" }
+redis-module-macros-internals = { path = "./redismodule-rs-macros-internals", version = "2.2.0" }
 log = "0.4"
 common = { path = "./common", package = "redis-module-common", version = "0.1.1" }
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,22 @@ See the [examples](examples) directory for some sample modules.
 This crate tries to provide high-level wrappers around the standard Redis Modules API, while preserving the API's basic concepts.
 Therefore, following the [Redis Modules API](https://redis.io/topics/modules-intro) documentation will be mostly relevant here as well.
 
+# Versioning and releases
+
+All crates in this repository are released from `master` and published to
+[crates.io](https://crates.io/crates/redis-module) by
+[release-plz](https://release-plz.dev).
+
+The `v2.1.0` through `v2.1.3` git tags were cut from the `2.1` branch and were
+not published to crates.io. Published versions from 2.2.0 onward include all
+changes from that branch. Projects pinning those tags as git dependencies can
+use the published crate instead:
+
+```toml
+[dependencies]
+redis-module = "2.2"
+```
+
 # Redis Modules based on this crate
 
 The following are some modules that are built on this crate:

--- a/redismodule-rs-macros-internals/CHANGELOG.md
+++ b/redismodule-rs-macros-internals/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.0](https://github.com/RedisLabsModules/redismodule-rs/compare/redis-module-macros-internals-v2.0.8...redis-module-macros-internals-v2.2.0) - 2026-07-09
+
+### Other
+
+- No functional changes. The version moves with the workspace from 2.0.8 to 2.2.0.
+
 ## [2.0.8](https://github.com/RedisLabsModules/redismodule-rs/compare/redis-module-macros-internals-v2.0.7...redis-module-macros-internals-v2.0.8) - 2026-05-04
 
 ### Fixed

--- a/redismodule-rs-macros/CHANGELOG.md
+++ b/redismodule-rs-macros/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.0](https://github.com/RedisLabsModules/redismodule-rs/compare/redis-module-macros-v2.0.8...redis-module-macros-v2.2.0) - 2026-07-09
+
+### Other
+
+- No functional changes. The version moves with the workspace from 2.0.8 to 2.2.0.
+
 ## [2.0.8](https://github.com/RedisLabsModules/redismodule-rs/compare/redis-module-macros-v2.0.7...redis-module-macros-v2.0.8) - 2026-05-04
 
 ### Fixed

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,12 @@
+# Tag and name redis-module releases as vX.Y.Z, matching the existing tag
+# format (v2.0.8, v2.1.3, ...), and mark only the redis-module release as
+# the latest GitHub release, so /releases/latest points at the main crate.
+# Other crates keep the default <crate>-vX.Y.Z tag and release names.
+[workspace]
+git_release_latest = false
+
+[[package]]
+name = "redis-module"
+git_tag_name = "v{{ version }}"
+git_release_name = "v{{ version }}"
+git_release_latest = true


### PR DESCRIPTION
The crates on crates.io are at 2.0.8. Git tags v2.1.0 through v2.1.3 were cut from the `2.1` branch and were not published to crates.io. All changes from that branch are present on `master`.

This bumps the workspace version from 2.0.8 to 2.2.0 so the next published version is ahead of the v2.1.x tags, adds the matching changelog entries, adds a README section describing how releases are published, and adds a release-plz config that tags and names redis-module releases as `v<version>`, matching the existing format.

Merging this triggers the existing release-plz workflow, which publishes 2.2.0 to crates.io, creates the `v2.2.0` tag, and creates a GitHub release named `v2.2.0`. After that, crates.io, the latest GitHub release, and the latest `v`-prefixed tag all point to the same version.

Closes #415