### PR TITLE
fix: make logging total on messages with interior NUL bytes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,6 +129,10 @@ crate-type = ["cdylib"]
 name = "expire"
 crate-type = ["cdylib"]
 
+[[example]]
+name = "log"
+crate-type = ["cdylib"]
+
 [dependencies]
 bitflags = "2"
 libc = "0.2"

--- a/examples/log.rs
+++ b/examples/log.rs
@@ -1,0 +1,28 @@
+use redis_module::{redis_module, Context, RedisError, RedisResult, RedisString};
+
+/// Logs a message that contains an interior NUL byte, the way a module logging
+/// a binary-safe key or other client-controlled bytes would. Redis keys may
+/// contain `\0`, which is the one byte `CString::new` rejects; before the fix
+/// this panicked inside the logging call and unwound across the `extern "C"`
+/// boundary, aborting the server. This command exists so the integration test
+/// can prove logging is total.
+fn log_with_nul(ctx: &Context, args: Vec<RedisString>) -> RedisResult {
+    if args.len() > 1 {
+        return Err(RedisError::WrongArity);
+    }
+
+    ctx.log_notice("processing key=a\0b");
+    Ok("Logged".into())
+}
+
+//////////////////////////////////////////////////////
+
+redis_module! {
+    name: "log",
+    version: 1,
+    allocator: (redis_module::alloc::RedisAlloc, redis_module::alloc::RedisAlloc),
+    data_types: [],
+    commands: [
+        ["log.with_nul", log_with_nul, "", 0, 0, 0, ""],
+    ],
+}

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -28,6 +28,18 @@ impl From<log::Level> for RedisLogLevel {
     }
 }
 
+/// Turn an arbitrary log message into a `CString` that can never fail to
+/// build. Redis keys are binary-safe and log messages routinely interpolate
+/// client-controlled bytes, so a message may contain an interior NUL, the one
+/// byte `CString::new` rejects. Escaping NUL to `\0` keeps the log line total
+/// and diagnostic instead of panicking across the FFI boundary and aborting the
+/// server. The `unwrap_or_else` fallback is unreachable (the input no longer
+/// contains NUL) but avoids a second `unwrap`.
+fn sanitize_message(message: &str) -> CString {
+    CString::new(message.replace('\0', "\\0"))
+        .unwrap_or_else(|_| CString::new("<unloggable message>").unwrap())
+}
+
 pub(crate) fn log_internal<L: Into<RedisLogLevel>>(
     ctx: *mut raw::RedisModuleCtx,
     level: L,
@@ -38,7 +50,7 @@ pub(crate) fn log_internal<L: Into<RedisLogLevel>>(
     }
 
     let level = CString::new(level.into().as_ref()).unwrap();
-    let fmt = CString::new(message).unwrap();
+    let fmt = sanitize_message(message);
     unsafe {
         raw::RedisModule_Log.expect(NOT_INITIALISED_MESSAGE)(ctx, level.as_ptr(), fmt.as_ptr())
     }
@@ -52,7 +64,7 @@ pub fn log_io_error(io: *mut raw::RedisModuleIO, level: RedisLogLevel, message: 
         return;
     }
     let level = CString::new(level.as_ref()).unwrap();
-    let fmt = CString::new(message).unwrap();
+    let fmt = sanitize_message(message);
     unsafe {
         raw::RedisModule_LogIOError.expect(NOT_INITIALISED_MESSAGE)(
             io,
@@ -194,3 +206,23 @@ pub mod standard_log_implementation {
     }
 }
 pub use standard_log_implementation::*;
+
+#[cfg(test)]
+mod tests {
+    use super::sanitize_message;
+
+    #[test]
+    fn sanitize_message_passes_through_clean_messages() {
+        assert_eq!(
+            sanitize_message("plain message").to_bytes(),
+            b"plain message"
+        );
+    }
+
+    #[test]
+    fn sanitize_message_escapes_interior_nul() {
+        // A NUL byte would make `CString::new` fail; it must be escaped, not
+        // rejected. This is the case that used to panic across the FFI boundary.
+        assert_eq!(sanitize_message("key=a\0b").to_bytes(), b"key=a\\0b");
+    }
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -419,6 +419,24 @@ fn test_key_space_notification_with_invalid_utf8_event_name() -> Result<()> {
 }
 
 #[test]
+fn test_logging_message_with_interior_nul() -> Result<()> {
+    let mut con = TestConnection::new("log");
+
+    // Logs a message containing an interior NUL byte. Redis keys are
+    // binary-safe, so a module logging a key can hand the logging path a `\0`,
+    // which `CString::new` rejects. The logging call must sanitize it rather
+    // than panic across the FFI boundary.
+    let res: String = redis::cmd("log.with_nul").query(&mut con)?;
+    assert_eq!(res, "Logged");
+
+    // The server survived.
+    let res: String = redis::cmd("PING").query(&mut con)?;
+    assert_eq!(res, "PONG");
+
+    Ok(())
+}
+
+#[test]
 fn test_context_mutex() -> Result<()> {
     let mut con = TestConnection::new("threads");
 


### PR DESCRIPTION
## Summary

`log_internal` and `log_io_error` in `src/logging.rs` built the log message with `CString::new(message).unwrap()`, which panics on any interior NUL byte. Because logging runs inside `extern "C"` callbacks (command handlers, keyspace-notification handlers, post-notification jobs), that panic unwinds across the FFI boundary and aborts the `redis-server` process.

Redis keys are binary-safe and may contain `\0`, so any module that logs a key (or other client-controlled bytes) crashes the server the first time such a key arrives, e.g.:

```rust
ctx.log_debug(&format!("processing key={}", String::from_utf8_lossy(key)));
```

`from_utf8_lossy` preserves NUL (it's valid UTF-8), `CString::new` rejects it, and the `unwrap` panics inside the callback.

## Fix

Route both call sites through a `sanitize_message` helper that escapes NUL to `\0`, so the logging path is total: it keeps a diagnostic log line instead of becoming a crash path. This preserves the full message (vs. truncating at the first NUL) and needs no public API change.

The issue named `log_internal`; `log_io_error` (the RDB/IO error path) had the identical bug, so this fixes both.

## Testing

- Unit tests for `sanitize_message` (clean passthrough + NUL escaping).
- Integration test `test_logging_message_with_interior_nul`: a new `log` example module logs a message containing an interior NUL, and the test asserts the command returns and the server still responds to `PING`. `cfg!(test)` short-circuits `log_internal` in unit builds, so the example-module path is what actually exercises the real logging call.

`cargo fmt`, `cargo clippy --workspace --all-targets`, and the full test suite pass locally against Redis 8.8.0.

Fixes #473
