### PR TITLE
feat: vendor the bigredis swap-prefetch API

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -25,7 +25,10 @@ impl ParseCallbacks for RedisModuleCallback {
                 name: "isize",
                 is_signed: true,
             })
-        } else if name.starts_with("REDISMODULE_NOTIFY_") {
+        } else if name.starts_with("REDISMODULE_NOTIFY_")
+            || name.starts_with("REDISMODULE_SWAP_PREFETCH_FLAG_")
+        {
+            // These are passed as `int` arguments to API functions.
             Some(IntKind::Int)
         } else {
             None

--- a/src/include/redismodule.h
+++ b/src/include/redismodule.h
@@ -80,6 +80,11 @@ typedef long long ustime_t;
 #define REDISMODULE_LIST_HEAD 0
 #define REDISMODULE_LIST_TAIL 1
 
+/* Flags for RedisModule_SwapPrefetchKey */
+#define REDISMODULE_SWAP_PREFETCH_FLAG_NOONE 0
+#define REDISMODULE_SWAP_PREFETCH_FLAG_NO_TOUCH (1<<0)
+#define REDISMODULE_SWAP_PREFETCH_FLAG_NO_DUP (1<<1) /* skip if already scheduled. */
+
 /* Key types. */
 #define REDISMODULE_KEYTYPE_EMPTY 0
 #define REDISMODULE_KEYTYPE_STRING 1
@@ -1476,6 +1481,10 @@ REDISMODULE_API const char * (*RedisModule_GetInternalSecret)(RedisModuleCtx *ct
 
 /* bigredis extensions
  * -------------------*/
+typedef void (*RedisModuleSwapPrefetchCB)(RedisModuleCtx *ctx, RedisModuleString *key, void* user_data);
+
+REDISMODULE_API int (*RedisModule_SwapPrefetchKey)(RedisModuleCtx *ctx, RedisModuleString *keyname, RedisModuleSwapPrefetchCB fn, void *user_data, int flags) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_IsKeyInRam)(RedisModuleCtx *ctx, RedisModuleString *key) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_BigModuleRegister)(RedisModuleCtx *ctx, RedisModuleBigCallbacks *callbacks) REDISMODULE_ATTR;
 REDISMODULE_API ssize_t (*RedisModule_BigWriteBufferBudgetInit)(RedisModuleCtx *ctx, int percentage) REDISMODULE_ATTR;
 REDISMODULE_API void (*RedisModule_BigWriteBufferBudgetRelease)(RedisModuleCtx *ctx) REDISMODULE_ATTR;
@@ -1903,6 +1912,8 @@ static int RedisModule_InitAPI(RedisModuleCtx *ctx) {
     REDISMODULE_GET_API(GetKeyMeta);
 
     /* Bigredis Extensions */
+    REDISMODULE_GET_API(IsKeyInRam);
+    REDISMODULE_GET_API(SwapPrefetchKey);
     REDISMODULE_GET_API(BigModuleRegister);
     REDISMODULE_GET_API(BigWriteBufferBudgetInit);
     REDISMODULE_GET_API(BigWriteBufferBudgetRelease);


### PR DESCRIPTION
Vendors `RedisModule_SwapPrefetchKey`, `RedisModule_IsKeyInRam`, the `RedisModuleSwapPrefetchCB` typedef and the three `REDISMODULE_SWAP_PREFETCH_FLAG_*` constants, and wires both pointers up in `RedisModule_InitAPI`.

Together these let a module read a bigredis keyspace without blocking on disk I/O: `IsKeyInRam` reports whether a key is resident, `SwapPrefetchKey` schedules a swap-in and fires a callback once it lands. Both are RLEC extensions our vendored header did not carry, even though it already carries the rest of the bigredis block. RediSearchEnterprise hand-declares them downstream today.

Two notes for review:

- The declarations are copied verbatim from RediSearch's `src/redismodule.h` and sit in the same position relative to the `RedisModule_Big*` block, so a future re-vendor diffs cleanly. The declaration order and the reversed `REDISMODULE_GET_API` order are both upstream's, preserved rather than tidied.
- `build.rs` gains one `int_macro` mapping so the flag constants emit as `c_int` rather than bindgen's default `u32`, since they are passed as `SwapPrefetchKey`'s `int flags` argument. Same arm that already handles `REDISMODULE_NOTIFY_*`.

No safe wrapper is added — callers reach these through `redis_module::raw`, as with the rest of the bigredis block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)