### PR TITLE
feat: add try_scan/try_for_each to the scan cursors

### DIFF
--- a/examples/scan_keys.rs
+++ b/examples/scan_keys.rs
@@ -5,6 +5,11 @@
 // 1. `scan_keys` - scans all keys in the database and returns their names as an array of RedisString.
 // 2. `scan_key <key>` - scans all fields by using a closure and a  while loop, thus allowing an early stop. Don't use the early stop but collects all the field/value pairs as an array of RedisString.
 // 3. `scan_key_for_each <key>` - scans all fields and values in a hash key using a closure that stores the field/value pairs as an array of RedisString.
+// 4. `scan_keys_for_each` - same as `scan_keys`, but using the callback based `for_each` loop.
+// 5. `scan_keys_limit <n>` - scans keys until `n` of them have been collected, then stops early.
+// 6. `scan_key_limit <key> <n>` - scans a hash key until `n` field/value pairs have been collected, then stops early.
+
+use std::ops::ControlFlow;
 
 use redis_module::{
     key::{KeyFlags, RedisKey},
@@ -24,6 +29,70 @@ fn scan_keys(ctx: &Context, _args: Vec<RedisString>) -> RedisResult {
     while cursor.scan(ctx, &scan_callback) {
         // do nothing
     }
+    Ok(RedisValue::Array(res))
+}
+
+/// Same as `scan_keys`, but lets the cursor drive the loop.
+fn scan_keys_for_each(ctx: &Context, _args: Vec<RedisString>) -> RedisResult {
+    let cursor = KeysCursor::new();
+    let mut res = Vec::new();
+
+    cursor.for_each(ctx, |ctx, key_name, _key| {
+        res.push(RedisValue::BulkRedisString(key_name.safe_clone(ctx)));
+    });
+
+    Ok(RedisValue::Array(res))
+}
+
+/// Collects at most `n` key names and then stops scanning. Note that a break abandons the scan:
+/// the keys Redis had already handed to the cursor in the current batch are skipped for good.
+fn scan_keys_limit(ctx: &Context, args: Vec<RedisString>) -> RedisResult {
+    if args.len() != 2 {
+        return Err(RedisError::WrongArity);
+    }
+    let limit = args[1].parse_unsigned_integer()? as usize;
+
+    let cursor = KeysCursor::new();
+    let mut res = Vec::new();
+
+    // We don't care whether we stopped early or ran out of keys, so the `ControlFlow` is dropped.
+    let _ = cursor.try_for_each(ctx, |ctx, key_name, _key| {
+        if res.len() >= limit {
+            return ControlFlow::Break(());
+        }
+        res.push(RedisValue::BulkRedisString(key_name.safe_clone(ctx)));
+        ControlFlow::Continue(())
+    });
+
+    Ok(RedisValue::Array(res))
+}
+
+/// Collects at most `n` field/value pairs of a hash key and then stops scanning.
+fn scan_key_limit(ctx: &Context, args: Vec<RedisString>) -> RedisResult {
+    if args.len() != 3 {
+        return Err(RedisError::WrongArity);
+    }
+    let limit = args[2].parse_unsigned_integer()? as usize;
+
+    let key = ctx.open_key_with_flags(
+        &args[1],
+        KeyFlags::NOEFFECTS | KeyFlags::NOEXPIRE | KeyFlags::ACCESS_EXPIRED,
+    );
+    let cursor = ScanKeyCursor::new(key);
+
+    let mut pairs = 0;
+    let mut res = Vec::new();
+
+    let _ = cursor.try_for_each(|_key, field, value| {
+        if pairs >= limit {
+            return ControlFlow::Break(());
+        }
+        res.push(RedisValue::BulkRedisString(field.clone()));
+        res.push(RedisValue::BulkRedisString(value.clone()));
+        pairs += 1;
+        ControlFlow::Continue(())
+    });
+
     Ok(RedisValue::Array(res))
 }
 
@@ -86,5 +155,8 @@ redis_module! {
         ["scan_keys", scan_keys, "readonly", 0, 0, 0, ""],
         ["scan_key", scan_key, "readonly", 0, 0, 0, ""],
         ["scan_key_for_each", scan_key_for_each, "readonly", 0, 0, 0, ""],
+        ["scan_keys_for_each", scan_keys_for_each, "readonly", 0, 0, 0, ""],
+        ["scan_keys_limit", scan_keys_limit, "readonly", 0, 0, 0, ""],
+        ["scan_key_limit", scan_key_limit, "readonly", 0, 0, 0, ""],
     ],
 }

--- a/src/context/key_cursor.rs
+++ b/src/context/key_cursor.rs
@@ -1,10 +1,19 @@
 use std::{
+    convert::Infallible,
     ffi::c_void,
     mem,
+    ops::ControlFlow,
     ptr::{self},
 };
 
 use crate::{key::RedisKey, raw, RedisString};
+
+/// The state handed to `RedisModule_ScanKey` as private data by the `try_*` methods: the user
+/// callback plus the value it broke with, if it did.
+struct TryScanState<B, F> {
+    callback: F,
+    broken: Option<B>,
+}
 
 /// A cursor to scan field/value pairs of a (hash) key.
 ///
@@ -77,27 +86,90 @@ impl ScanKeyCursor {
     /// }) {
     ///   // do something between scans if needed, like an early stop
     /// }
-    pub fn scan<F: FnMut(&RedisKey, &RedisString, &RedisString)>(&self, f: F) -> bool {
-        unsafe extern "C" fn scan_callback<F: FnMut(&RedisKey, &RedisString, &RedisString)>(
+    pub fn scan<F: FnMut(&RedisKey, &RedisString, &RedisString)>(&self, mut f: F) -> bool {
+        let flow = self.try_scan(|key, field, value| {
+            f(key, field, value);
+            ControlFlow::<Infallible>::Continue(())
+        });
+        match flow {
+            ControlFlow::Continue(more) => more,
+            // `Infallible` is uninhabited, so the callback above can never have broken.
+            ControlFlow::Break(never) => match never {},
+        }
+    }
+
+    /// Implements a callback based for_each loop over all fields and values in the hash key.
+    /// If you need more control, e.g. stopping after a scan invocation, then use [`ScanKeyCursor::scan`] directly.
+    pub fn for_each<F: FnMut(&RedisKey, &RedisString, &RedisString)>(&self, mut f: F) {
+        while self.scan(&mut f) {
+            // do nothing, the callback does the work
+        }
+    }
+
+    /// Like [`ScanKeyCursor::scan`], but the callback may return [`ControlFlow::Break`] to stop
+    /// early. Returns `ControlFlow::Continue(true)` if there are more fields to scan,
+    /// `ControlFlow::Continue(false)` if the key has been fully scanned, and `ControlFlow::Break`
+    /// with the callback's value if the callback broke.
+    ///
+    /// # Breaking abandons the scan
+    ///
+    /// `RedisModule_ScanKey` cannot be aborted while it is running: it always finishes the batch
+    /// of elements it is working on and advances the cursor past all of them. Breaking therefore
+    /// only stops *your* callback from running; the elements after the break point in the current
+    /// batch are skipped and will *not* be seen if you keep scanning with the same cursor.
+    ///
+    /// How much gets skipped depends on the encoding of the value. For hashtable and skiplist
+    /// encodings a batch is a single hash bucket, but for the compact encodings (listpack,
+    /// intset, ...) Redis walks the *entire* value in one invocation and marks the cursor as
+    /// done. So on a small hash, breaking leaves the cursor exhausted, and a further
+    /// [`ScanKeyCursor::try_for_each`] returns `Continue(())` immediately even though fields were
+    /// never visited. Treat a break as abandoning the scan, and call [`ScanKeyCursor::restart`]
+    /// if you need to go again.
+    pub fn try_scan<B, F: FnMut(&RedisKey, &RedisString, &RedisString) -> ControlFlow<B>>(
+        &self,
+        callback: F,
+    ) -> ControlFlow<B, bool> {
+        unsafe extern "C" fn scan_callback<
+            B,
+            F: FnMut(&RedisKey, &RedisString, &RedisString) -> ControlFlow<B>,
+        >(
             key: *mut raw::RedisModuleKey,
             field: *mut raw::RedisModuleString,
             value: *mut raw::RedisModuleString,
             data: *mut c_void,
         ) {
+            // Safety: `data` is the `*mut TryScanState<B, F>` that `try_scan` derived from a
+            // `&mut` to a live local, and Redis only calls us from inside that
+            // `RedisModule_ScanKey` call.
+            let state = unsafe { &mut *(data.cast::<TryScanState<B, F>>()) };
+
+            // `RedisModuleScanKeyCB` returns `void`, so there is no way to tell Redis to stop
+            // iterating. Once the callback has broken we simply do no more work, without even
+            // constructing the wrapper types for the remaining elements of this invocation.
+            if state.broken.is_some() {
+                return;
+            }
+
             let ctx = ptr::null_mut();
             let key = RedisKey::from_raw_parts(ctx, key);
 
             let field = RedisString::from_redis_module_string(ctx, field);
             let value = RedisString::from_redis_module_string(ctx, value);
 
-            let callback = unsafe { &mut *(data.cast::<F>()) };
-            callback(&key, &field, &value);
+            if let ControlFlow::Break(broken) = (state.callback)(&key, &field, &value) {
+                state.broken = Some(broken);
+            }
 
             // We don't own any of the passed in pointers, so we must ensure we don't run their destructors here
             mem::forget(field);
             mem::forget(value);
             mem::forget(key);
         }
+
+        let mut state = TryScanState {
+            callback,
+            broken: None,
+        };
 
         // Safety: The c-side initialized the function ptr and it is is never changed,
         // i.e. after module initialization the function pointers stay valid till the end of the program.
@@ -107,20 +179,28 @@ impl ScanKeyCursor {
             scan_key(
                 self.key.key_inner,
                 self.inner_cursor,
-                Some(scan_callback::<F>),
-                &f as *const F as *mut c_void,
+                Some(scan_callback::<B, F>),
+                (&mut state as *mut TryScanState<B, F>).cast::<c_void>(),
             )
         };
 
-        res != 0
+        match state.broken {
+            Some(broken) => ControlFlow::Break(broken),
+            None => ControlFlow::Continue(res != 0),
+        }
     }
 
-    /// Implements a callback based for_each loop over all fields and values in the hash key.
-    /// If you need more control, e.g. stopping after a scan invocation, then use [`ScanKeyCursor::scan`] directly.
-    pub fn for_each<F: FnMut(&RedisKey, &RedisString, &RedisString)>(&self, mut f: F) {
-        while self.scan(&mut f) {
-            // do nothing, the callback does the work
-        }
+    /// Loops over all fields and values in the hash key until it is exhausted or the callback
+    /// returns [`ControlFlow::Break`]. The analogue of [`Iterator::try_for_each`].
+    ///
+    /// See [`ScanKeyCursor::try_scan`] for what breaking does to the cursor, and the
+    /// `scan_key_limit` command in `examples/scan_keys.rs` for a worked example.
+    pub fn try_for_each<B, F: FnMut(&RedisKey, &RedisString, &RedisString) -> ControlFlow<B>>(
+        &self,
+        mut callback: F,
+    ) -> ControlFlow<B> {
+        while self.try_scan(&mut callback)? {}
+        ControlFlow::Continue(())
     }
 }
 

--- a/src/context/keys_cursor.rs
+++ b/src/context/keys_cursor.rs
@@ -2,12 +2,21 @@ use crate::context::Context;
 use crate::key::RedisKey;
 use crate::raw;
 use crate::redismodule::RedisString;
+use std::convert::Infallible;
 use std::ffi::c_void;
 use std::mem;
+use std::ops::ControlFlow;
 use std::ptr::NonNull;
 
 pub struct KeysCursor {
     inner_cursor: *mut raw::RedisModuleScanCursor,
+}
+
+/// The state handed to `RedisModule_Scan` as private data by the `try_*` methods: the user
+/// callback plus the value it broke with, if it did.
+struct TryScanState<B, F> {
+    callback: F,
+    broken: Option<B>,
 }
 
 extern "C" fn scan_callback<C: FnMut(&Context, &RedisString, Option<&RedisKey>)>(
@@ -27,6 +36,48 @@ extern "C" fn scan_callback<C: FnMut(&Context, &RedisString, Option<&RedisKey>)>
     };
     let callback = unsafe { &mut *(private_data.cast::<C>()) };
     callback(&context, &key_name, redis_key.as_ref());
+
+    // We don't own any of the passed in pointers and have just created "temporary RAII types".
+    // We must ensure we don't run their destructors here.
+    mem::forget(redis_key);
+    mem::forget(key_name);
+}
+
+/// `scan` cannot share this callback: it only holds a `&F`, so the `&F -> &mut F` cast it needs to
+/// call the `FnMut` has to stay hidden behind the `*mut c_void` round trip through Redis.
+extern "C" fn try_scan_callback<
+    B,
+    C: FnMut(&Context, &RedisString, Option<&RedisKey>) -> ControlFlow<B>,
+>(
+    ctx: *mut raw::RedisModuleCtx,
+    key_name: *mut raw::RedisModuleString,
+    key: *mut raw::RedisModuleKey,
+    private_data: *mut ::std::os::raw::c_void,
+) {
+    // Safety: `private_data` is the `*mut TryScanState<B, C>` that `try_scan` derived from a
+    // `&mut` to a live local, and Redis only calls us from inside that `RedisModule_Scan` call.
+    let state = unsafe { &mut *(private_data.cast::<TryScanState<B, C>>()) };
+
+    // `RedisModuleScanCB` returns `void`, so there is no way to tell Redis to stop iterating.
+    // Once the callback has broken we simply do no more work, without even constructing the
+    // wrapper types for the remaining keys of this invocation.
+    if state.broken.is_some() {
+        return;
+    }
+
+    let context = Context::new(ctx);
+    let key_name = RedisString::new(NonNull::new(ctx), key_name);
+    let redis_key = if key.is_null() {
+        None
+    } else {
+        // Safety: The returned `RedisKey` does not outlive this callbacks and so by necessity
+        // the pointers passed in as parameters are valid for its entire lifetime.
+        Some(unsafe { RedisKey::from_raw_parts(ctx, key) })
+    };
+
+    if let ControlFlow::Break(value) = (state.callback)(&context, &key_name, redis_key.as_ref()) {
+        state.broken = Some(value);
+    }
 
     // We don't own any of the passed in pointers and have just created "temporary RAII types".
     // We must ensure we don't run their destructors here.
@@ -54,6 +105,79 @@ impl KeysCursor {
             )
         };
         res != 0
+    }
+
+    /// Scans all keys of the current database, calling `callback` for each one.
+    ///
+    /// If you need to stop before the whole keyspace has been visited, use
+    /// [`KeysCursor::try_for_each`] instead.
+    pub fn for_each<F: FnMut(&Context, &RedisString, Option<&RedisKey>)>(
+        &self,
+        ctx: &Context,
+        mut callback: F,
+    ) {
+        let flow = self.try_for_each(ctx, |ctx, key_name, key| {
+            callback(ctx, key_name, key);
+            ControlFlow::<Infallible>::Continue(())
+        });
+        match flow {
+            ControlFlow::Continue(()) => (),
+            // `Infallible` is uninhabited, so the callback above can never have broken.
+            ControlFlow::Break(never) => match never {},
+        }
+    }
+
+    /// Like [`KeysCursor::scan`], but the callback may return [`ControlFlow::Break`] to stop
+    /// early. Returns `ControlFlow::Continue(true)` if there are more keys to scan,
+    /// `ControlFlow::Continue(false)` if the keyspace has been fully scanned, and
+    /// `ControlFlow::Break` with the callback's value if the callback broke.
+    ///
+    /// # Breaking abandons the scan
+    ///
+    /// `RedisModule_Scan` cannot be aborted while it is running: it always finishes the batch of
+    /// keys it is working on and advances the cursor past all of them. Breaking therefore only
+    /// stops *your* callback from running; the keys after the break point in the current batch
+    /// are skipped and will *not* be seen if you keep scanning with the same cursor. Treat a
+    /// break as abandoning the scan, and call [`KeysCursor::restart`] if you need to go again.
+    pub fn try_scan<B, F: FnMut(&Context, &RedisString, Option<&RedisKey>) -> ControlFlow<B>>(
+        &self,
+        ctx: &Context,
+        callback: F,
+    ) -> ControlFlow<B, bool> {
+        let mut state = TryScanState {
+            callback,
+            broken: None,
+        };
+        let res = unsafe {
+            raw::RedisModule_Scan.unwrap()(
+                ctx.ctx,
+                self.inner_cursor,
+                Some(try_scan_callback::<B, F>),
+                (&mut state as *mut TryScanState<B, F>).cast::<c_void>(),
+            )
+        };
+        match state.broken {
+            Some(value) => ControlFlow::Break(value),
+            None => ControlFlow::Continue(res != 0),
+        }
+    }
+
+    /// Scans all keys of the current database, calling `callback` for each one, until the
+    /// keyspace is exhausted or the callback returns [`ControlFlow::Break`]. The analogue of
+    /// [`Iterator::try_for_each`].
+    ///
+    /// See [`KeysCursor::try_scan`] for what breaking does to the cursor, and the `scan_keys_limit`
+    /// command in `examples/scan_keys.rs` for a worked example.
+    pub fn try_for_each<
+        B,
+        F: FnMut(&Context, &RedisString, Option<&RedisKey>) -> ControlFlow<B>,
+    >(
+        &self,
+        ctx: &Context,
+        mut callback: F,
+    ) -> ControlFlow<B> {
+        while self.try_scan(ctx, &mut callback)? {}
+        ControlFlow::Continue(())
     }
 
     pub fn restart(&self) {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -237,6 +237,99 @@ fn test_scan_key_for_each() -> Result<()> {
 }
 
 #[test]
+fn test_scan_keys_for_each() -> Result<()> {
+    let mut con = TestConnection::new("scan_keys");
+
+    redis::cmd("set")
+        .arg(&["x", "1"])
+        .query::<()>(&mut con)
+        .with_context(|| "failed to run set")?;
+
+    redis::cmd("set")
+        .arg(&["y", "1"])
+        .query::<()>(&mut con)
+        .with_context(|| "failed to run set")?;
+
+    let mut res: Vec<String> = redis::cmd("scan_keys_for_each")
+        .query(&mut con)
+        .with_context(|| "failed scan_keys_for_each")?;
+    res.sort();
+
+    assert_eq!(&res, &["x", "y"]);
+
+    Ok(())
+}
+
+#[test]
+fn test_scan_keys_limit() -> Result<()> {
+    let mut con = TestConnection::new("scan_keys");
+
+    for key in ["a", "b", "c", "d"] {
+        redis::cmd("set")
+            .arg(&[key, "1"])
+            .query::<()>(&mut con)
+            .with_context(|| "failed to run set")?;
+    }
+
+    // The keyspace is scanned in hash-table order, so we can only assert on how many keys the
+    // early stop let through, not on which ones.
+    let res: Vec<String> = redis::cmd("scan_keys_limit")
+        .arg(&[2])
+        .query(&mut con)
+        .with_context(|| "failed scan_keys_limit")?;
+    assert_eq!(res.len(), 2);
+
+    let res: Vec<String> = redis::cmd("scan_keys_limit")
+        .arg(&[10])
+        .query(&mut con)
+        .with_context(|| "failed scan_keys_limit")?;
+    assert_eq!(res.len(), 4);
+
+    // A limit of zero breaks on the very first callback, before anything is collected.
+    let res: Vec<String> = redis::cmd("scan_keys_limit")
+        .arg(&[0])
+        .query(&mut con)
+        .with_context(|| "failed scan_keys_limit")?;
+    assert!(res.is_empty());
+
+    Ok(())
+}
+
+#[test]
+fn test_scan_key_limit() -> Result<()> {
+    let mut con = TestConnection::new("scan_keys");
+    redis::cmd("hset")
+        .arg(&[
+            "user:123", "name", "Alice", "age", "29", "location", "Austin",
+        ])
+        .query::<()>(&mut con)
+        .with_context(|| "failed to hset")?;
+
+    // A small hash is listpack encoded, which Redis walks in insertion order and in a single
+    // `RedisModule_ScanKey` call: breaking is the only way to stop before the end.
+    let res: Vec<String> = redis::cmd("scan_key_limit")
+        .arg(&["user:123", "2"])
+        .query(&mut con)
+        .with_context(|| "failed scan_key_limit")?;
+    assert_eq!(&res, &["name", "Alice", "age", "29"]);
+
+    let res: Vec<String> = redis::cmd("scan_key_limit")
+        .arg(&["user:123", "10"])
+        .query(&mut con)
+        .with_context(|| "failed scan_key_limit")?;
+    assert_eq!(&res, &["name", "Alice", "age", "29", "location", "Austin"]);
+
+    // A limit of zero breaks on the very first callback, before anything is collected.
+    let res: Vec<String> = redis::cmd("scan_key_limit")
+        .arg(&["user:123", "0"])
+        .query(&mut con)
+        .with_context(|| "failed scan_key_limit")?;
+    assert!(res.is_empty());
+
+    Ok(())
+}
+
+#[test]
 fn test_stream_reader() -> Result<()> {
     let mut con = TestConnection::new("stream");
 


### PR DESCRIPTION
Both `KeysCursor` and `ScanKeyCursor` could only scan to completion: the callback had no way to signal "stop". That gap is most visible on `ScanKeyCursor`, where a listpack-encoded value is walked entirely within a single `RedisModule_ScanKey` call, so the existing `while cursor.scan(..)` loop never gets a chance to break.

Add `try_scan` and `try_for_each` to both cursors. The callback returns `ControlFlow<B>`, and `try_for_each` is the analogue of `Iterator::try_for_each` -- it stops issuing scan calls as soon as the callback breaks and propagates the break value. `KeysCursor` also gains the `for_each` that `ScanKeyCursor` already had.

`RedisModuleScanCB` and `RedisModuleScanKeyCB` both return `void`, so Redis cannot be aborted mid-batch: it finishes the batch and advances the cursor past all of it. Breaking therefore stops the user callback, not Redis's iteration, and the rest of the current batch is skipped for good. Both `try_scan` doc comments spell this out, including how much gets skipped per encoding.

`ScanKeyCursor::scan` now delegates to `try_scan`, which removes its duplicate `extern "C"` callback along with the `&f as *const F as *mut c_void` cast it needed. `KeysCursor::scan` cannot do the same: it only holds a `&F`, and hoisting the `&F -> &mut F` cast out of the callback trips the deny-by-default `invalid_reference_casting` lint, so it keeps its own callback unchanged.

Covered by three new example commands and three integration tests, including one that returns exactly the first two pairs of a three-field listpack hash.


Claude-Session: https://claude.ai/code/session_01Rykj2WP9fzGjnseyrnVgBf