### PR TITLE
[MOD-17680] Honour layouts requiring more than 16-byte alignment

### DIFF
--- a/src/alloc.rs
+++ b/src/alloc.rs
@@ -1,4 +1,5 @@
 use std::alloc::{GlobalAlloc, Layout};
+use std::ptr;
 
 use crate::raw;
 
@@ -18,6 +19,21 @@ fn allocation_free_panic(message: &'static str) -> ! {
 
 const REDIS_ALLOCATOR_NOT_AVAILABLE_MESSAGE: &str =
     "Critical error: the Redis Allocator isn't available.\n";
+
+/// The alignment `RedisModule_Alloc` provides on its own.
+///
+/// It is Redis' `zmalloc`, which forwards to an allocator handing out
+/// `max_align_t`-aligned addresses — jemalloc, tcmalloc or libc `malloc`
+/// depending on how the server was built.
+///
+/// Understating this costs an unnecessary fixup; overstating it hands out
+/// under-aligned memory, so it is the weakest guarantee those allocators share
+/// rather than the strongest any of them happens to provide.
+const MIN_ALIGN: usize = 2 * std::mem::size_of::<usize>();
+
+/// Size of the header kept directly below an over-aligned block, holding the
+/// pointer that has to be given back to `RedisModule_Free`.
+const HEADER: usize = std::mem::size_of::<*mut u8>();
 
 /// Defines the Redis allocator. This allocator delegates the allocation
 /// and deallocation tasks to the Redis server when available, otherwise
@@ -44,10 +60,15 @@ unsafe impl GlobalAlloc for RedisAlloc {
 }
 
 /// Allocate `layout` through `alloc`, which is expected to behave like
-/// `RedisModule_Alloc`: it takes a size, and returns a block aligned for any
-/// fundamental type and no more.
+/// `RedisModule_Alloc`: it takes a size, and returns a block aligned to at most
+/// [`MIN_ALIGN`].
 ///
-/// Returns a null pointer if `alloc` does.
+/// Layouts within [`MIN_ALIGN`] are served by `alloc` directly. A stricter one
+/// cannot be — the module API has no aligned-allocation primitive — so it is
+/// carved out of a larger block instead, with the underlying pointer stored in
+/// the [`HEADER`] word below the address returned to the caller.
+///
+/// Returns a null pointer if `alloc` does, or if the padded size overflows.
 ///
 /// Taking the allocator as a closure keeps this testable without a running
 /// Redis server behind `RedisModule_Alloc`.
@@ -56,20 +77,41 @@ unsafe impl GlobalAlloc for RedisAlloc {
 ///
 /// `alloc` must behave like [`GlobalAlloc::alloc`] for the size it is given.
 unsafe fn alloc_aligned(layout: Layout, alloc: impl FnOnce(usize) -> *mut u8) -> *mut u8 {
-    /*
-     * To make sure the memory allocation by Redis is aligned to the according to the layout,
-     * we need to align the size of the allocation to the layout.
-     *
-     * "Memory is conceptually broken into equal-sized chunks,
-     * where the chunk size is a power of two that is greater than the page size.
-     * Chunks are always aligned to multiples of the chunk size.
-     * This alignment makes it possible to find metadata for user objects very quickly."
-     *
-     * From: https://linux.die.net/man/3/jemalloc
-     */
-    let size = (layout.size() + layout.align() - 1) & (!(layout.align() - 1));
+    if layout.align() <= MIN_ALIGN {
+        /*
+         * To make sure the memory allocation by Redis is aligned to the according to the layout,
+         * we need to align the size of the allocation to the layout.
+         *
+         * "Memory is conceptually broken into equal-sized chunks,
+         * where the chunk size is a power of two that is greater than the page size.
+         * Chunks are always aligned to multiples of the chunk size.
+         * This alignment makes it possible to find metadata for user objects very quickly."
+         *
+         * From: https://linux.die.net/man/3/jemalloc
+         */
+        let size = (layout.size() + layout.align() - 1) & (!(layout.align() - 1));
 
-    alloc(size)
+        return alloc(size);
+    }
+
+    // Worst case the block starts one byte past an aligned address, so reaching
+    // the next one from just above the header costs `align - 1` further bytes.
+    let Some(size) = layout.size().checked_add(layout.align() + HEADER) else {
+        return ptr::null_mut();
+    };
+
+    let base = alloc(size);
+    if base.is_null() {
+        return base;
+    }
+
+    let offset = (base.addr() + HEADER).next_multiple_of(layout.align()) - base.addr();
+    let ptr = base.add(offset);
+    // Storing the pointer rather than the offset keeps the provenance Redis gave
+    // us, so `dealloc_aligned` hands back exactly what `alloc` returned.
+    ptr.cast::<*mut u8>().sub(1).write(base);
+
+    ptr
 }
 
 /// Free a pointer produced by [`alloc_aligned`] through the matching `free`.
@@ -78,7 +120,15 @@ unsafe fn alloc_aligned(layout: Layout, alloc: impl FnOnce(usize) -> *mut u8) ->
 ///
 /// `ptr` must have come from [`alloc_aligned`] with this same `layout`, and
 /// `free` must release blocks allocated by the closure that call was given.
-unsafe fn dealloc_aligned(ptr: *mut u8, _layout: Layout, free: impl FnOnce(*mut u8)) {
+unsafe fn dealloc_aligned(ptr: *mut u8, layout: Layout, free: impl FnOnce(*mut u8)) {
+    let ptr = if layout.align() <= MIN_ALIGN {
+        ptr
+    } else {
+        // `alloc_aligned` took the same branch for this layout, so the word below
+        // `ptr` is inside the allocation and holds the underlying pointer.
+        ptr.cast::<*mut u8>().sub(1).read()
+    };
+
     free(ptr);
 }
 
@@ -87,17 +137,6 @@ mod tests {
     use super::*;
     use std::alloc::System;
     use std::cell::Cell;
-    use std::ptr;
-
-    /// The alignment `RedisModule_Alloc` provides on its own, and so the most
-    /// [`Zmalloc`] may hand out.
-    ///
-    /// It is Redis' `zmalloc`, which forwards to an allocator handing out
-    /// `max_align_t`-aligned addresses — jemalloc, tcmalloc or libc `malloc`
-    /// depending on how the server was built. This is the weakest guarantee
-    /// those allocators share rather than the strongest any of them happens to
-    /// provide, since a caller may only rely on the former.
-    const MIN_ALIGN: usize = 2 * std::mem::size_of::<usize>();
 
     /// A block handed out by [`Zmalloc`], and what it takes to give it back.
     #[derive(Clone, Copy)]

--- a/src/alloc.rs
+++ b/src/alloc.rs
@@ -27,29 +27,232 @@ pub struct RedisAlloc;
 
 unsafe impl GlobalAlloc for RedisAlloc {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
-        /*
-         * To make sure the memory allocation by Redis is aligned to the according to the layout,
-         * we need to align the size of the allocation to the layout.
-         *
-         * "Memory is conceptually broken into equal-sized chunks,
-         * where the chunk size is a power of two that is greater than the page size.
-         * Chunks are always aligned to multiples of the chunk size.
-         * This alignment makes it possible to find metadata for user objects very quickly."
-         *
-         * From: https://linux.die.net/man/3/jemalloc
-         */
-        let size = (layout.size() + layout.align() - 1) & (!(layout.align() - 1));
+        let Some(alloc) = raw::RedisModule_Alloc else {
+            allocation_free_panic(REDIS_ALLOCATOR_NOT_AVAILABLE_MESSAGE)
+        };
 
-        match raw::RedisModule_Alloc {
-            Some(alloc) => alloc(size).cast(),
-            None => allocation_free_panic(REDIS_ALLOCATOR_NOT_AVAILABLE_MESSAGE),
+        alloc_aligned(layout, |size| alloc(size).cast())
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        let Some(free) = raw::RedisModule_Free else {
+            allocation_free_panic(REDIS_ALLOCATOR_NOT_AVAILABLE_MESSAGE)
+        };
+
+        dealloc_aligned(ptr, layout, |ptr| free(ptr.cast()));
+    }
+}
+
+/// Allocate `layout` through `alloc`, which is expected to behave like
+/// `RedisModule_Alloc`: it takes a size, and returns a block aligned for any
+/// fundamental type and no more.
+///
+/// Returns a null pointer if `alloc` does.
+///
+/// Taking the allocator as a closure keeps this testable without a running
+/// Redis server behind `RedisModule_Alloc`.
+///
+/// # Safety
+///
+/// `alloc` must behave like [`GlobalAlloc::alloc`] for the size it is given.
+unsafe fn alloc_aligned(layout: Layout, alloc: impl FnOnce(usize) -> *mut u8) -> *mut u8 {
+    /*
+     * To make sure the memory allocation by Redis is aligned to the according to the layout,
+     * we need to align the size of the allocation to the layout.
+     *
+     * "Memory is conceptually broken into equal-sized chunks,
+     * where the chunk size is a power of two that is greater than the page size.
+     * Chunks are always aligned to multiples of the chunk size.
+     * This alignment makes it possible to find metadata for user objects very quickly."
+     *
+     * From: https://linux.die.net/man/3/jemalloc
+     */
+    let size = (layout.size() + layout.align() - 1) & (!(layout.align() - 1));
+
+    alloc(size)
+}
+
+/// Free a pointer produced by [`alloc_aligned`] through the matching `free`.
+///
+/// # Safety
+///
+/// `ptr` must have come from [`alloc_aligned`] with this same `layout`, and
+/// `free` must release blocks allocated by the closure that call was given.
+unsafe fn dealloc_aligned(ptr: *mut u8, _layout: Layout, free: impl FnOnce(*mut u8)) {
+    free(ptr);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::alloc::System;
+    use std::cell::Cell;
+    use std::ptr;
+
+    /// The alignment `RedisModule_Alloc` provides on its own, and so the most
+    /// [`Zmalloc`] may hand out.
+    ///
+    /// It is Redis' `zmalloc`, which forwards to an allocator handing out
+    /// `max_align_t`-aligned addresses — jemalloc, tcmalloc or libc `malloc`
+    /// depending on how the server was built. This is the weakest guarantee
+    /// those allocators share rather than the strongest any of them happens to
+    /// provide, since a caller may only rely on the former.
+    const MIN_ALIGN: usize = 2 * std::mem::size_of::<usize>();
+
+    /// A block handed out by [`Zmalloc`], and what it takes to give it back.
+    #[derive(Clone, Copy)]
+    struct Block {
+        /// What `System` returned, along with the layout it has to be given back
+        /// with.
+        base: *mut u8,
+        layout: Layout,
+        /// What [`Zmalloc::alloc`] returned, and so what [`Zmalloc::free`] has to
+        /// be handed.
+        handed_out: *mut u8,
+        /// The size [`alloc_aligned`] asked for, before this double padded it.
+        requested: usize,
+    }
+
+    /// Stands in for `RedisModule_Alloc`, which cannot be called without a
+    /// running server. Like `zmalloc` it takes only a size, and it returns the
+    /// weakest thing `zmalloc` may return: a block aligned to exactly
+    /// [`MIN_ALIGN`] and never more.
+    ///
+    /// That last part is deliberate. Real allocators over-align by chance often
+    /// enough that under-aligned allocations go unnoticed on Linux for years, and
+    /// a double inheriting that luck would pass these tests against an
+    /// implementation that never aligns anything.
+    #[derive(Default)]
+    struct Zmalloc {
+        last: Cell<Option<Block>>,
+    }
+
+    impl Zmalloc {
+        fn alloc(&self, requested: usize) -> *mut u8 {
+            // Room to push the block off a stricter boundary when it lands on one.
+            let layout = Layout::from_size_align(requested + MIN_ALIGN, MIN_ALIGN).unwrap();
+            let base = unsafe { System.alloc(layout) };
+
+            let offset = if base.addr() % (2 * MIN_ALIGN) == 0 {
+                MIN_ALIGN
+            } else {
+                0
+            };
+            let handed_out = unsafe { base.add(offset) };
+            assert_eq!(
+                handed_out.addr() % (2 * MIN_ALIGN),
+                MIN_ALIGN,
+                "the double is over-aligning, so it no longer models the worst case"
+            );
+
+            self.last.set(Some(Block {
+                base,
+                layout,
+                handed_out,
+                requested,
+            }));
+
+            handed_out
+        }
+
+        fn free(&self, ptr: *mut u8) {
+            let block = self.last();
+            assert_eq!(
+                ptr, block.handed_out,
+                "freed a pointer that was never allocated"
+            );
+            unsafe { System.dealloc(block.base, block.layout) };
+        }
+
+        fn last(&self) -> Block {
+            self.last.get().unwrap()
         }
     }
 
-    unsafe fn dealloc(&self, ptr: *mut u8, _layout: Layout) {
-        match raw::RedisModule_Free {
-            Some(f) => f(ptr.cast()),
-            None => allocation_free_panic(REDIS_ALLOCATOR_NOT_AVAILABLE_MESSAGE),
-        };
+    /// Alignments above [`MIN_ALIGN`] worth covering: the 32 bytes an AVX2
+    /// searcher needs, plus a cache line and a page.
+    const OVER_ALIGNED: [usize; 3] = [32, 64, 4096];
+
+    const _: () = assert!(OVER_ALIGNED[0] > MIN_ALIGN, "these no longer over-align");
+
+    #[test]
+    fn layouts_within_min_align_are_served_directly() {
+        // Every alignment the fast path claims, derived rather than listed: on a
+        // target where `MIN_ALIGN` is 8 a hard-coded 16 would exercise the other
+        // branch instead.
+        for align in (0..=MIN_ALIGN.ilog2()).map(|shift| 1usize << shift) {
+            let zmalloc = Zmalloc::default();
+            let layout = Layout::from_size_align(24, align).unwrap();
+
+            let ptr = unsafe { alloc_aligned(layout, |size| zmalloc.alloc(size)) };
+
+            assert!(!ptr.is_null());
+            assert_eq!(ptr, zmalloc.last().handed_out, "align {align} was adjusted");
+
+            unsafe { dealloc_aligned(ptr, layout, |ptr| zmalloc.free(ptr)) };
+        }
+    }
+
+    #[test]
+    fn a_request_smaller_than_its_alignment_is_rounded_up() {
+        let zmalloc = Zmalloc::default();
+        let layout = Layout::from_size_align(8, MIN_ALIGN).unwrap();
+
+        let ptr = unsafe { alloc_aligned(layout, |size| zmalloc.alloc(size)) };
+
+        // The rounding is what lifts the request into a size class the allocator
+        // returns suitably aligned; without it a `malloc(8)` may only be
+        // 8-aligned.
+        assert_eq!(zmalloc.last().requested, MIN_ALIGN);
+
+        unsafe { dealloc_aligned(ptr, layout, |ptr| zmalloc.free(ptr)) };
+    }
+
+    #[test]
+    fn over_aligned_blocks_are_aligned_and_usable() {
+        for align in OVER_ALIGNED {
+            for size in [1, align, 7 * align] {
+                let zmalloc = Zmalloc::default();
+                let layout = Layout::from_size_align(size, align).unwrap();
+
+                let ptr = unsafe { alloc_aligned(layout, |size| zmalloc.alloc(size)) };
+
+                assert!(!ptr.is_null());
+                assert_eq!(ptr.addr() % align, 0, "size {size} align {align}");
+
+                // Touching every byte proves the block really extends that far.
+                // Miri and the sanitizers fail the test if it does not.
+                unsafe { ptr.write_bytes(0xAB, size) };
+
+                unsafe { dealloc_aligned(ptr, layout, |ptr| zmalloc.free(ptr)) };
+            }
+        }
+    }
+
+    #[test]
+    fn over_aligned_blocks_are_freed_at_the_underlying_pointer() {
+        let zmalloc = Zmalloc::default();
+        let layout = Layout::from_size_align(100, 64).unwrap();
+
+        let ptr = unsafe { alloc_aligned(layout, |size| zmalloc.alloc(size)) };
+        assert_ne!(
+            ptr,
+            zmalloc.last().handed_out,
+            "test needs a layout that gets adjusted"
+        );
+
+        // `Zmalloc::free` asserts it was handed its own pointer back.
+        unsafe { dealloc_aligned(ptr, layout, |ptr| zmalloc.free(ptr)) };
+    }
+
+    #[test]
+    fn a_failed_allocation_propagates_null() {
+        let layout = Layout::from_size_align(64, 64).unwrap();
+
+        let ptr = unsafe { alloc_aligned(layout, |_| ptr::null_mut()) };
+
+        // Null must come straight back out: writing a header below it would
+        // dereference the null pointer.
+        assert!(ptr.is_null());
     }
 }

--- a/src/alloc.rs
+++ b/src/alloc.rs
@@ -284,6 +284,58 @@ mod tests {
         unsafe { dealloc_aligned(ptr, layout, |ptr| zmalloc.free(ptr)) };
     }
 
+    thread_local! {
+        /// The [`Zmalloc`] the `RedisModule_*` doubles below hand out blocks
+        /// from. They are plain `extern "C"` function pointers, so they cannot
+        /// capture one the way the other tests capture a local.
+        static ZMALLOC: Zmalloc = Zmalloc::default();
+    }
+
+    unsafe extern "C" fn zmalloc(bytes: usize) -> *mut std::os::raw::c_void {
+        ZMALLOC.with(|zmalloc| zmalloc.alloc(bytes)).cast()
+    }
+
+    unsafe extern "C" fn zfree(ptr: *mut std::os::raw::c_void) {
+        ZMALLOC.with(|zmalloc| zmalloc.free(ptr.cast()));
+    }
+
+    /// Every other test here drives `alloc_aligned` directly, so none of them
+    /// executes the `GlobalAlloc` impl: the `RedisModule_Alloc` lookup, the
+    /// casts around it, and `dealloc` routing through `dealloc_aligned`.
+    /// Wiring either side to the wrong thing passes all of them.
+    ///
+    /// This is the only test that writes the `RedisModule_*` statics, and the
+    /// double behind them tracks one block at a time, so it has to stay that
+    /// way. Miri cannot access those externs at all, hence the `ignore`.
+    #[test]
+    #[cfg_attr(miri, ignore = "cannot access the RedisModule_* extern statics")]
+    fn the_global_allocator_serves_over_aligned_layouts() {
+        #[repr(align(64))]
+        struct OverAligned([u8; 256]);
+
+        unsafe {
+            raw::RedisModule_Alloc = Some(zmalloc);
+            raw::RedisModule_Free = Some(zfree);
+        }
+
+        let layout = Layout::new::<OverAligned>();
+        let ptr = unsafe { RedisAlloc.alloc(layout) }.cast::<OverAligned>();
+
+        assert!(!ptr.is_null());
+        assert_eq!(ptr.addr() % layout.align(), 0);
+
+        // A typed access, unlike the byte writes elsewhere in this module:
+        // `panic_misaligned_pointer_dereference` fires on a load or store whose
+        // type the address is under-aligned for, and never on a byte one, so
+        // this is what would have aborted before the fix.
+        unsafe { ptr.write(OverAligned([0xAB; 256])) };
+        assert_eq!(unsafe { &*ptr }.0, [0xAB; 256]);
+
+        // `Zmalloc::free` asserts it was handed its own pointer back, which
+        // covers the header round-trip through `dealloc`.
+        unsafe { RedisAlloc.dealloc(ptr.cast(), layout) };
+    }
+
     #[test]
     fn a_failed_allocation_propagates_null() {
         let layout = Layout::from_size_align(64, 64).unwrap();


### PR DESCRIPTION
Tracked as [MOD-17680](https://redislabs.atlassian.net/browse/MOD-17680).

## Problem

`RedisAlloc::alloc` rounds the requested **size** up to the layout's alignment, but never
obtains an aligned **address**:

```rust
let size = (layout.size() + layout.align() - 1) & (!(layout.align() - 1));
alloc(size).cast()
```

`RedisModule_Alloc` is `zmalloc`, which returns `max_align_t`-aligned memory — 16 bytes on
the platforms this crate targets. Any `Layout` asking for more than that is silently
served under-aligned, which is undefined behaviour. In a build with debug assertions the
first dereference of such a pointer trips
`core::panicking::panic_misaligned_pointer_dereference` and the process aborts; in a
release build it is a latent SIGSEGV on instructions that require alignment.

Whether it is observed depends entirely on what the platform allocator happens to return:

- **Linux** — jemalloc's size classes usually return a sufficiently aligned address by
  accident, so the defect stays hidden.
- **aarch64** — over-aligned types are rarer, so the code path is often never taken.
- **macOS x86_64** — neither applies, and it aborts.

We hit this in RediSearch. `memchr::memmem::Finder` embeds a `packedpair::Finder<__m256i>`
on AVX2 targets, giving it `align = 32`; boxing one and dereferencing it aborts the server
on every `CONTAINS` query. Dispatching the same test suite twice on a macOS x86_64 runner
gave 22 misaligned-pointer aborts and 19 failed tests without a fix, versus 0 and 0 with
one, over the same 4355 executed tests. That run validated an equivalent fix rather than
this diff: a downstream crate wrapping `RedisAlloc` with the same
over-allocate-and-store-the-header scheme. This PR folds the scheme into `RedisAlloc`
itself, so the algorithm is the one that was measured but the code is not.

## Change

The module API has no aligned-allocation primitive — `RedisModule_Alloc`, `Calloc`,
`Realloc`, `TryAlloc` and `MallocSize` all take or report a plain size — so an
over-aligned block has to be carved out of a larger one by hand. `alloc` now
over-allocates by `align + size_of::<*mut u8>()`, returns the first suitably aligned
address at or above the header, and stores the pointer that must be given back to
`RedisModule_Free` in the word directly below it. `dealloc` reads that word back.

Two things are deliberate:

- **Layouts within `MIN_ALIGN` keep the existing path, size rounding included.** That
  rounding is load-bearing: for `Layout(size = 8, align = 16)` a bare `malloc(8)` under
  jemalloc may return only 8-aligned memory, so removing it would introduce on Linux
  exactly the bug this PR fixes on macOS. There is a regression test for it.
- **The header stores the pointer, not the offset**, so the provenance Redis handed out is
  preserved and `dealloc` returns the very pointer `alloc` received.

`dealloc` has to start reading its `layout` argument (it was `_layout`) to know which
branch `alloc` took, so the two cannot be changed independently.

`realloc` and `alloc_zeroed` are not overridden, and the `GlobalAlloc` defaults compose
correctly with this: they are defined in terms of `alloc`/`dealloc`, so an over-aligned
block is reallocated as allocate-copy-free rather than through `RedisModule_Realloc`.
That is a small cost paid only by over-aligned layouts, which are rare.

## Compatibility

One behavioural note worth flagging: an over-aligned block now has a header below it, so a
pointer allocated by Rust and freed directly by C with `RedisModule_Free` would free the
user address rather than the base. Layouts up to 16 bytes of alignment — every such
pointer that exists today, since the crate could not previously produce anything else
usable — are completely untouched by this patch and keep working as before.

`DefragContext` has the same seam: `defrag_alloc` goes through the global allocator, while
`defrag_realloc` passes its pointer to `RedisModule_DefragAlloc`, which expects one that
came straight from `RM_Alloc`. For an over-aligned layout those two no longer compose — the
header would have Redis defragment an interior pointer, and a block that moved would carry
a stale base into its new location. Nothing is affected today: the only user of that
pairing I could find is RedisJSON's `DefragCtxAllocator`, and every layout `ijson` sends
through it is an `align(8)` header extended with primitive arrays. Nor does anything that
worked before stop working — an over-aligned `defrag_alloc` used to return memory that was
under-aligned for its own layout, so it could not be dereferenced at all. Letting the
defrag path carry over-aligned blocks needs a way to tell global-allocator pointers from
raw `RM_Alloc` ones, which is a separate change.

## Testing

`alloc`/`dealloc` are thin wrappers over `alloc_aligned`/`dealloc_aligned`, which take the
underlying allocator as a closure. That is what makes them testable without a running
Redis server behind the `RedisModule_*` function pointers; the tests substitute a
`zmalloc` double that mimics its contract — takes only a size, always returns
`MIN_ALIGN`-aligned memory — and asserts it is handed its own pointer back on free.

Five unit tests cover the fast path, the size-rounding regression, alignment and
usability of the over-aligned path across `[32, 64, 4096]`, freeing at the underlying
pointer, and null propagation. They pass under `cargo test` and under `cargo miri test`,
which is what actually checks the pointer arithmetic for provenance and out-of-bounds
access.

`cargo fmt --check` and `cargo clippy --workspace --all-targets` are clean (the one
remaining clippy warning is pre-existing, in `examples/proc_macro_commands.rs`).
