### PR TITLE
MOD-18400: Expose WBM budget APIs in Rust

### DIFF
--- a/src/include/redismodule.h
+++ b/src/include/redismodule.h
@@ -1488,6 +1488,8 @@ REDISMODULE_API int (*RedisModule_IsKeyInRam)(RedisModuleCtx *ctx, RedisModuleSt
 REDISMODULE_API int (*RedisModule_BigModuleRegister)(RedisModuleCtx *ctx, RedisModuleBigCallbacks *callbacks) REDISMODULE_ATTR;
 REDISMODULE_API ssize_t (*RedisModule_BigWriteBufferBudgetInit)(RedisModuleCtx *ctx, int percentage) REDISMODULE_ATTR;
 REDISMODULE_API void (*RedisModule_BigWriteBufferBudgetRelease)(RedisModuleCtx *ctx) REDISMODULE_ATTR;
+REDISMODULE_API ssize_t (*RedisModule_AllocateWBMBudget)(RedisModuleCtx *ctx, size_t requested_bytes) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_FreeWBMBudget)(RedisModuleCtx *ctx, size_t bytes) REDISMODULE_ATTR;
 REDISMODULE_API char* (*RedisModule_BigGetDbPath)(RedisModuleCtx *ctx, const char *index_name) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_BigRegisterDb)(RedisModuleCtx *ctx, void *db_handle, void **cf_handles, size_t num_cf_handles) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_BigRegisterDbAddCf)(RedisModuleCtx *ctx, void *db_handle, void *cf_handle) REDISMODULE_ATTR;
@@ -1917,6 +1919,8 @@ static int RedisModule_InitAPI(RedisModuleCtx *ctx) {
     REDISMODULE_GET_API(BigModuleRegister);
     REDISMODULE_GET_API(BigWriteBufferBudgetInit);
     REDISMODULE_GET_API(BigWriteBufferBudgetRelease);
+    REDISMODULE_GET_API(AllocateWBMBudget);
+    REDISMODULE_GET_API(FreeWBMBudget);
     REDISMODULE_GET_API(BigGetDbPath);
     REDISMODULE_GET_API(BigRegisterDb);
     REDISMODULE_GET_API(BigRegisterDbAddCf);

--- a/src/include/redismodule.h
+++ b/src/include/redismodule.h
@@ -1488,8 +1488,7 @@ REDISMODULE_API int (*RedisModule_IsKeyInRam)(RedisModuleCtx *ctx, RedisModuleSt
 REDISMODULE_API int (*RedisModule_BigModuleRegister)(RedisModuleCtx *ctx, RedisModuleBigCallbacks *callbacks) REDISMODULE_ATTR;
 REDISMODULE_API ssize_t (*RedisModule_BigWriteBufferBudgetInit)(RedisModuleCtx *ctx, int percentage) REDISMODULE_ATTR;
 REDISMODULE_API void (*RedisModule_BigWriteBufferBudgetRelease)(RedisModuleCtx *ctx) REDISMODULE_ATTR;
-REDISMODULE_API ssize_t (*RedisModule_AllocateWBMBudget)(RedisModuleCtx *ctx, size_t requested_bytes) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_FreeWBMBudget)(RedisModuleCtx *ctx, size_t bytes) REDISMODULE_ATTR;
+REDISMODULE_API ssize_t (*RedisModule_SetWriteBufferBudget)(RedisModuleCtx *ctx, size_t requested_total) REDISMODULE_ATTR;
 REDISMODULE_API char* (*RedisModule_BigGetDbPath)(RedisModuleCtx *ctx, const char *index_name) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_BigRegisterDb)(RedisModuleCtx *ctx, void *db_handle, void **cf_handles, size_t num_cf_handles) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_BigRegisterDbAddCf)(RedisModuleCtx *ctx, void *db_handle, void *cf_handle) REDISMODULE_ATTR;
@@ -1919,8 +1918,7 @@ static int RedisModule_InitAPI(RedisModuleCtx *ctx) {
     REDISMODULE_GET_API(BigModuleRegister);
     REDISMODULE_GET_API(BigWriteBufferBudgetInit);
     REDISMODULE_GET_API(BigWriteBufferBudgetRelease);
-    REDISMODULE_GET_API(AllocateWBMBudget);
-    REDISMODULE_GET_API(FreeWBMBudget);
+    REDISMODULE_GET_API(SetWriteBufferBudget);
     REDISMODULE_GET_API(BigGetDbPath);
     REDISMODULE_GET_API(BigRegisterDb);
     REDISMODULE_GET_API(BigRegisterDbAddCf);


### PR DESCRIPTION
Rust modules need declarations and API lookup wiring for Redis's module write-buffer-manager budget interface. This exposes `RedisModule_AllocateWBMBudget` and `RedisModule_FreeWBMBudget` through the vendored module header so consumers can compile against the new API.

The corresponding Redis implementation is tracked in https://github.com/redislabsdev/Redis/pull/1783.

Validation:
- `cargo fmt --all -- --check`
- `cargo check --all-targets`
- `cargo test --lib` (6 passed)

